### PR TITLE
ci: update GitHub Actions to .NET 10 SDK

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -5,19 +5,25 @@ on: [push]
 jobs:
   build_docker_image:
     env:
-      PersistenceModule__DefaultConnection: Server=localhost;User Id=sa;Password=<YourStrong!Passw0rd>;Database=Accounts;
+      PersistenceModule__DefaultConnection: Server=localhost;User Id=sa;Password=${{ secrets.SA_PASSWORD }};Database=Accounts;
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
+        dotnet-version: '10.0.x'
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
     - name: Setup Database then Run Tests
       run: |
         dotnet --version
-        docker pull mcr.microsoft.com/mssql/server:2019-latest
-        docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=<YourStrong!Passw0rd>' -p 1433:1433 --name sql1 -d mcr.microsoft.com/mssql/server:2019-latest
+        docker pull mcr.microsoft.com/mssql/server:2022-latest
+        docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=${{ secrets.SA_PASSWORD }}' -p 1433:1433 --name sql1 -d mcr.microsoft.com/mssql/server:2022-latest
         sleep 10
         dotnet build
         pushd accounts-api


### PR DESCRIPTION
## Summary

Updates the CI workflow to use .NET 10 SDK and modernizes GitHub Actions dependencies, removing hardcoded credentials in favor of GitHub Secrets.

Fixes #6

## Changes

- **SDK**: Updated `dotnet-version` from `6.0.x` to `10.0.x`
- **SQL Server**: Updated Docker image from `2019-latest` to `2022-latest`
- **Security**: Replaced hardcoded SA password (`<YourStrong!Passw0rd>`) with `${{ secrets.SA_PASSWORD }}` in both the connection string env var and the Docker run command
- **Actions**: Bumped `actions/checkout` v3 -> v4, `actions/setup-dotnet` v3 -> v4
- **Caching**: Added NuGet package caching via `actions/cache@v4` keyed on `*.csproj` files
- **Cleanup**: Removed `include-prerelease: true` (not needed for a stable SDK release)

## Testing

- CI will validate the workflow runs successfully on push
- Requires `SA_PASSWORD` to be configured as a repository secret before the workflow can pass