### PR TITLE
chore: update Dockerfiles to .NET 10 base images

### DIFF
--- a/accounts-api-seed/Dockerfile
+++ b/accounts-api-seed/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
-RUN dotnet tool update --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 10.0.*
 WORKDIR /src
 COPY . .
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false


### PR DESCRIPTION
## Summary

Ensures all Dockerfiles are fully aligned with .NET 10 and pins the `dotnet-ef` tool version for reproducible builds.

Fixes #5

## Changes

- **accounts-api-seed/Dockerfile** — Pin `dotnet-ef` to `10.0.*` and switch from `dotnet tool update` to `dotnet tool install` for deterministic Docker layer caching
- **accounts-api/src/WebApi/Dockerfile** — Already using `sdk:10.0` / `aspnet:10.0-alpine` (no change needed)
- **identity-server/Dockerfile** — Already using `sdk:10.0` / `aspnet:10.0-alpine` (no change needed)

## Testing

- [ ] `docker build -f accounts-api-seed/Dockerfile .` succeeds
- [ ] `docker build -f accounts-api/src/WebApi/Dockerfile ./accounts-api` succeeds
- [ ] `docker build -f identity-server/Dockerfile .` succeeds
- [ ] Multi-stage builds produce correct final images