### PR TITLE
chore: upgrade NuGet packages to .NET 10 compatible versions

### DIFF
--- a/accounts-api/src/Infrastructure/Infrastructure.csproj
+++ b/accounts-api/src/Infrastructure/Infrastructure.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/identity-server/IdentityServer.csproj
+++ b/identity-server/IdentityServer.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Duende.IdentityServer" Version="7.4.6" />
 		<PackageReference Include="IdentityModel" Version="7.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />


### PR DESCRIPTION
## Summary

Upgrade all NuGet packages to their latest .NET 10 compatible versions, completing the dependency modernization started in PR #1.

## Changes

- **Newtonsoft.Json**: 13.0.3 → 13.0.4 (Infrastructure, IdentityServer)

### Already at latest (upgraded by PR #1)

| Package | Version |
|---|---|
| Microsoft.EntityFrameworkCore.* | 10.0.3 |
| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.3 |
| Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore | 10.0.3 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.3 |
| Microsoft.AspNetCore.Authentication.Google | 10.0.3 |
| Microsoft.FeatureManagement.AspNetCore | 4.4.0 |
| Swashbuckle.AspNetCore | 10.1.4 |
| EPPlus | 8.4.2 |
| Scrutor | 7.0.0 |
| xunit | 2.9.3 |
| xunit.runner.visualstudio | 3.1.5 |
| Microsoft.NET.Test.Sdk | 18.3.0 |
| coverlet.msbuild | 8.0.0 |
| prometheus-net.AspNetCore | 8.2.1 |
| Duende.IdentityServer | 7.4.6 |
| Serilog.AspNetCore | 10.0.0 |
| Asp.Versioning.Mvc | 8.1.1 |

### Deprecated packages already removed (by PR #1)

- `Microsoft.AspNetCore.Http` — included in framework since .NET Core 3.0
- `Microsoft.Extensions.PlatformAbstractions` — archived
- Hardcoded macOS `HintPath` for `Microsoft.AspNetCore.Http.Abstractions.dll`

## Deferred

- **Newtonsoft.Json → System.Text.Json**: Tracked in #9
- **Swashbuckle → Microsoft.AspNetCore.OpenApi**: Tracked in #11
- **prometheus-net → OpenTelemetry**: Tracked in #19

## Testing

- `dotnet build` succeeds (0 errors, 5 pre-existing ASP0019 warnings in IdentityServer)
- `dotnet test` — 14/14 unit tests pass; integration/e2e tests fail due to missing SQL Server infrastructure (pre-existing)
- `dotnet list package --outdated` confirms no further upgrades available (except deferred items above)

Fixes #4