### PR TITLE
Replace Newtonsoft.Json with System.Text.Json

### DIFF
--- a/accounts-api/src/Infrastructure/CurrencyExchange/CurrencyExchangeService.cs
+++ b/accounts-api/src/Infrastructure/CurrencyExchange/CurrencyExchangeService.cs
@@ -4,10 +4,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Application.Services;
 using Domain.ValueObjects;
-using Newtonsoft.Json.Linq;
 
 /// <summary>
 ///     Real implementation of the Exchange Service using external data source
@@ -57,12 +57,13 @@ public sealed class CurrencyExchangeService : ICurrencyExchange
 
     private void ParseCurrencies(string responseJson)
     {
-        JObject rates = JObject.Parse(responseJson);
-        decimal eur = rates["rates"]![Currency.Euro.Code]!.Value<decimal>();
-        decimal cad = rates["rates"]![Currency.Canadian.Code]!.Value<decimal>();
-        decimal gbh = rates["rates"]![Currency.BritishPound.Code]!.Value<decimal>();
-        decimal sek = rates["rates"]![Currency.Krona.Code]!.Value<decimal>();
-        decimal brl = rates["rates"]![Currency.Real.Code]!.Value<decimal>();
+        using JsonDocument document = JsonDocument.Parse(responseJson);
+        JsonElement rates = document.RootElement.GetProperty("rates");
+        decimal eur = rates.GetProperty(Currency.Euro.Code).GetDecimal();
+        decimal cad = rates.GetProperty(Currency.Canadian.Code).GetDecimal();
+        decimal gbh = rates.GetProperty(Currency.BritishPound.Code).GetDecimal();
+        decimal sek = rates.GetProperty(Currency.Krona.Code).GetDecimal();
+        decimal brl = rates.GetProperty(Currency.Real.Code).GetDecimal();
 
         this._usdRates.Add(Currency.Dollar, 1);
         this._usdRates.Add(Currency.Euro, eur);

--- a/accounts-api/src/Infrastructure/Infrastructure.csproj
+++ b/accounts-api/src/Infrastructure/Infrastructure.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/accounts-api/test/ComponentTests/V1/SunnyDayTests.cs
+++ b/accounts-api/test/ComponentTests/V1/SunnyDayTests.cs
@@ -3,11 +3,9 @@ namespace ComponentTests.V1;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 public sealed class SunnyDayTests : IClassFixture<CustomWebApplicationFactory>
@@ -26,14 +24,11 @@ public sealed class SunnyDayTests : IClassFixture<CustomWebApplicationFactory>
             .ReadAsStringAsync()
             ;
 
-        using StringReader stringReader = new StringReader(actualResponseString);
-        using JsonTextReader reader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None };
+        using JsonDocument jsonDocument = JsonDocument.Parse(actualResponseString);
+        JsonElement jsonResponse = jsonDocument.RootElement;
 
-        JObject jsonResponse = await JObject.LoadAsync(reader)
-            ;
-
-        Guid.TryParse(jsonResponse["accounts"]![0]!["accountId"]!.Value<string>(), out Guid accountId);
-        decimal.TryParse(jsonResponse["accounts"]![0]!["currentBalance"]!.Value<string>(),
+        Guid.TryParse(jsonResponse.GetProperty("accounts")[0].GetProperty("accountId").GetString(), out Guid accountId);
+        decimal.TryParse(jsonResponse.GetProperty("accounts")[0].GetProperty("currentBalance").GetRawText(),
             out decimal currentBalance);
 
         return new Tuple<Guid, decimal>(accountId, currentBalance);
@@ -46,14 +41,11 @@ public sealed class SunnyDayTests : IClassFixture<CustomWebApplicationFactory>
             .GetStringAsync($"/api/v1/Accounts/{accountId}")
             ;
 
-        using StringReader stringReader = new StringReader(actualResponseString);
-        using JsonTextReader reader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None };
+        using JsonDocument jsonDocument = JsonDocument.Parse(actualResponseString);
+        JsonElement jsonResponse = jsonDocument.RootElement;
 
-        JObject jsonResponse = await JObject.LoadAsync(reader)
-            ;
-
-        Guid.TryParse(jsonResponse["account"]!["accountId"]!.Value<string>(), out Guid getAccountId);
-        decimal.TryParse(jsonResponse["account"]!["currentBalance"]!.Value<string>(), out decimal currentBalance);
+        Guid.TryParse(jsonResponse.GetProperty("account").GetProperty("accountId").GetString(), out Guid getAccountId);
+        decimal.TryParse(jsonResponse.GetProperty("account").GetProperty("currentBalance").GetRawText(), out decimal currentBalance);
 
         return new Tuple<Guid, decimal>(getAccountId, currentBalance);
     }

--- a/accounts-api/test/ComponentTests/V2/SunnyDayTests.cs
+++ b/accounts-api/test/ComponentTests/V2/SunnyDayTests.cs
@@ -1,11 +1,9 @@
 namespace ComponentTests.V2;
 
 using System;
-using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 public sealed class SunnyDayTests : IClassFixture<CustomWebApplicationFactory>
@@ -24,14 +22,11 @@ public sealed class SunnyDayTests : IClassFixture<CustomWebApplicationFactory>
             .ReadAsStringAsync()
             ;
 
-        using StringReader stringReader = new StringReader(actualResponseString);
-        using JsonTextReader reader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None };
+        using JsonDocument jsonDocument = JsonDocument.Parse(actualResponseString);
+        JsonElement jsonResponse = jsonDocument.RootElement;
 
-        JObject jsonResponse = await JObject.LoadAsync(reader)
-            ;
-
-        Guid.TryParse(jsonResponse["accounts"]![0]!["accountId"]!.Value<string>(), out Guid accountId);
-        decimal.TryParse(jsonResponse["accounts"]![0]!["currentBalance"]!.Value<string>(),
+        Guid.TryParse(jsonResponse.GetProperty("accounts")[0].GetProperty("accountId").GetString(), out Guid accountId);
+        decimal.TryParse(jsonResponse.GetProperty("accounts")[0].GetProperty("currentBalance").GetRawText(),
             out decimal currentBalance);
 
         return new Tuple<Guid, decimal>(accountId, currentBalance);

--- a/identity-server/IdentityServer.csproj
+++ b/identity-server/IdentityServer.csproj
@@ -9,8 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Duende.IdentityServer" Version="7.4.6" />
 		<PackageReference Include="IdentityModel" Version="7.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.3" />
+<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
 	</ItemGroup>

--- a/identity-server/Quickstart/Diagnostics/DiagnosticsViewModel.cs
+++ b/identity-server/Quickstart/Diagnostics/DiagnosticsViewModel.cs
@@ -3,17 +3,11 @@
 
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json;
 using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
-using Newtonsoft.Json;
 
 namespace IdentityServer.Quickstart.Diagnostics;
-
-using System.Collections.Generic;
-using System.Text;
-using IdentityModel;
-using Microsoft.AspNetCore.Authentication;
-using Newtonsoft.Json;
 
 public class DiagnosticsViewModel
 {
@@ -27,7 +21,7 @@ public class DiagnosticsViewModel
             var bytes = Base64Url.Decode(encoded);
             var value = Encoding.UTF8.GetString(bytes);
 
-            Clients = JsonConvert.DeserializeObject<string[]>(value);
+            Clients = JsonSerializer.Deserialize<string[]>(value);
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaced all `Newtonsoft.Json` usage (`JObject`, `JProperty`, `JsonConvert`, `JsonTextReader`) with `System.Text.Json` equivalents (`JsonDocument`, `JsonElement`, `JsonSerializer`)
- Removed `Newtonsoft.Json` NuGet package from `Infrastructure.csproj` and `IdentityServer.csproj`
- Updated component tests to use `System.Text.Json` for JSON parsing

## Files changed
- `accounts-api/src/Infrastructure/CurrencyExchange/CurrencyExchangeService.cs` — `JObject.Parse` → `JsonDocument.Parse`
- `accounts-api/src/Infrastructure/Infrastructure.csproj` — removed Newtonsoft.Json package
- `accounts-api/src/WebApi/Modules/HealthChecksExtensions.cs` — `JObject`/`JProperty` → `Dictionary` + `JsonSerializer`
- `accounts-api/test/ComponentTests/V1/SunnyDayTests.cs` — `JsonTextReader`/`JObject` → `JsonDocument`
- `accounts-api/test/ComponentTests/V1/GetAccountsTests.cs` — same migration
- `accounts-api/test/ComponentTests/V2/SunnyDayTests.cs` — same migration
- `identity-server/IdentityServer.csproj` — removed Newtonsoft.Json package
- `identity-server/Quickstart/Diagnostics/DiagnosticsViewModel.cs` — `JsonConvert` → `JsonSerializer`

## Test plan
- [x] Solution builds with 0 errors
- [x] No remaining references to `Newtonsoft.Json` in the solution
- [ ] Currency exchange parsing works with `System.Text.Json`
- [ ] All API responses serialize correctly

Fixes #9