### PR TITLE
Add Kubernetes Helm charts for production deployment

### DIFF
--- a/k8s/charts/clean-architecture/Chart.yaml
+++ b/k8s/charts/clean-architecture/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: clean-architecture
+description: A Helm chart for the Clean Architecture Manga application stack
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - dotnet
+  - clean-architecture
+  - accounts-api
+  - wallet-app
+  - postgresql
+maintainers:
+  - name: Atypical Consulting
+    url: https://github.com/Atypical-Consulting

--- a/k8s/charts/clean-architecture/templates/_helpers.tpl
+++ b/k8s/charts/clean-architecture/templates/_helpers.tpl
@@ -1,0 +1,142 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clean-architecture.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "clean-architecture.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "clean-architecture.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "clean-architecture.labels" -}}
+helm.sh/chart: {{ include "clean-architecture.chart" . }}
+{{ include "clean-architecture.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "clean-architecture.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clean-architecture.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Accounts API fully qualified name
+*/}}
+{{- define "clean-architecture.accountsApi.fullname" -}}
+{{- printf "%s-accounts-api" (include "clean-architecture.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Accounts API labels
+*/}}
+{{- define "clean-architecture.accountsApi.labels" -}}
+helm.sh/chart: {{ include "clean-architecture.chart" . }}
+{{ include "clean-architecture.accountsApi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Accounts API selector labels
+*/}}
+{{- define "clean-architecture.accountsApi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clean-architecture.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: accounts-api
+{{- end }}
+
+{{/*
+Wallet App fully qualified name
+*/}}
+{{- define "clean-architecture.walletApp.fullname" -}}
+{{- printf "%s-wallet-app" (include "clean-architecture.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Wallet App labels
+*/}}
+{{- define "clean-architecture.walletApp.labels" -}}
+helm.sh/chart: {{ include "clean-architecture.chart" . }}
+{{ include "clean-architecture.walletApp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Wallet App selector labels
+*/}}
+{{- define "clean-architecture.walletApp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clean-architecture.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: wallet-app
+{{- end }}
+
+{{/*
+PostgreSQL fully qualified name
+*/}}
+{{- define "clean-architecture.postgresql.fullname" -}}
+{{- printf "%s-postgresql" (include "clean-architecture.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+PostgreSQL labels
+*/}}
+{{- define "clean-architecture.postgresql.labels" -}}
+helm.sh/chart: {{ include "clean-architecture.chart" . }}
+{{ include "clean-architecture.postgresql.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+PostgreSQL selector labels
+*/}}
+{{- define "clean-architecture.postgresql.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clean-architecture.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: postgresql
+{{- end }}
+
+{{/*
+PostgreSQL connection string
+*/}}
+{{- define "clean-architecture.postgresql.connectionString" -}}
+{{- printf "Host=%s;Port=%d;Database=%s;Username=%s;Password=$(POSTGRES_PASSWORD)" (include "clean-architecture.postgresql.fullname" .) (int .Values.postgresql.port) .Values.postgresql.database .Values.postgresql.username }}
+{{- end }}

--- a/k8s/charts/clean-architecture/templates/accounts-api/deployment.yaml
+++ b/k8s/charts/clean-architecture/templates/accounts-api/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clean-architecture.accountsApi.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.accountsApi.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.accountsApi.autoscaling.enabled }}
+  replicas: {{ .Values.accountsApi.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "clean-architecture.accountsApi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clean-architecture.accountsApi.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.accountsApi.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: accounts-api
+          image: "{{ .Values.accountsApi.image.repository }}:{{ .Values.accountsApi.image.tag }}"
+          imagePullPolicy: {{ .Values.accountsApi.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.accountsApi.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "clean-architecture.fullname" . }}-config
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clean-architecture.fullname" . }}-secrets
+                  key: POSTGRES_PASSWORD
+            - name: PersistenceModule__DefaultConnection
+              value: {{ include "clean-architecture.postgresql.connectionString" . | quote }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.accountsApi.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.accountsApi.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.accountsApi.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.accountsApi.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.accountsApi.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.accountsApi.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.accountsApi.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.accountsApi.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.accountsApi.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.accountsApi.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.accountsApi.resources | nindent 12 }}

--- a/k8s/charts/clean-architecture/templates/accounts-api/hpa.yaml
+++ b/k8s/charts/clean-architecture/templates/accounts-api/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.accountsApi.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "clean-architecture.accountsApi.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.accountsApi.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "clean-architecture.accountsApi.fullname" . }}
+  minReplicas: {{ .Values.accountsApi.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.accountsApi.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.accountsApi.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.accountsApi.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.accountsApi.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.accountsApi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/k8s/charts/clean-architecture/templates/accounts-api/ingress.yaml
+++ b/k8s/charts/clean-architecture/templates/accounts-api/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.accountsApi.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "clean-architecture.accountsApi.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.accountsApi.labels" . | nindent 4 }}
+  {{- with .Values.accountsApi.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.accountsApi.ingress.className }}
+  ingressClassName: {{ .Values.accountsApi.ingress.className }}
+  {{- end }}
+  {{- if .Values.accountsApi.ingress.tls }}
+  tls:
+    {{- range .Values.accountsApi.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.accountsApi.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "clean-architecture.accountsApi.fullname" $ }}
+                port:
+                  number: {{ $.Values.accountsApi.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/charts/clean-architecture/templates/accounts-api/service.yaml
+++ b/k8s/charts/clean-architecture/templates/accounts-api/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clean-architecture.accountsApi.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.accountsApi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.accountsApi.service.type }}
+  ports:
+    - port: {{ .Values.accountsApi.service.port }}
+      targetPort: {{ .Values.accountsApi.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "clean-architecture.accountsApi.selectorLabels" . | nindent 4 }}

--- a/k8s/charts/clean-architecture/templates/configmap.yaml
+++ b/k8s/charts/clean-architecture/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clean-architecture.fullname" . }}-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.labels" . | nindent 4 }}
+data:
+  ASPNETCORE_ENVIRONMENT: {{ .Values.accountsApi.environment | quote }}
+  ASPNETCORE_BASEPATH: {{ .Values.accountsApi.basePath | quote }}
+  ASPNETCORE_URLS: "http://+:{{ .Values.accountsApi.containerPort }}"
+  POSTGRES_HOST: {{ include "clean-architecture.postgresql.fullname" . | quote }}
+  POSTGRES_PORT: {{ .Values.postgresql.port | quote }}
+  POSTGRES_DB: {{ .Values.postgresql.database | quote }}
+  POSTGRES_USER: {{ .Values.postgresql.username | quote }}

--- a/k8s/charts/clean-architecture/templates/namespace.yaml
+++ b/k8s/charts/clean-architecture/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.labels" . | nindent 4 }}

--- a/k8s/charts/clean-architecture/templates/postgresql/pvc.yaml
+++ b/k8s/charts/clean-architecture/templates/postgresql/pvc.yaml
@@ -1,0 +1,14 @@
+{{/*
+PVC is managed by the StatefulSet's volumeClaimTemplates when persistence is enabled.
+This standalone PVC template is provided for cases where you need a pre-provisioned
+PersistentVolumeClaim outside the StatefulSet lifecycle (e.g., data migration).
+
+To use this standalone PVC instead of volumeClaimTemplates, set
+postgresql.persistence.standalone: true in your values file.
+*/}}
+{{- if and .Values.postgresql.enabled (not .Values.postgresql.persistence.enabled) }}
+{{/*
+When persistence is disabled, data is stored in an emptyDir volume.
+No PVC is created.
+*/}}
+{{- end }}

--- a/k8s/charts/clean-architecture/templates/postgresql/secret.yaml
+++ b/k8s/charts/clean-architecture/templates/postgresql/secret.yaml
@@ -1,0 +1,23 @@
+{{/*
+PostgreSQL credentials are managed by the shared secrets.yaml template
+at templates/secrets.yaml. This file is included for directory structure
+completeness as specified in the issue.
+
+If you need a dedicated PostgreSQL secret (e.g., for use with an external
+secret manager), uncomment the resource below and update the StatefulSet
+to reference this secret instead.
+*/}}
+{{/*
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clean-architecture.postgresql.fullname" . }}-credentials
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.postgresql.labels" . | nindent 4 }}
+type: Opaque
+data:
+  POSTGRES_PASSWORD: {{ .Values.postgresql.password | b64enc | quote }}
+{{- end }}
+*/}}

--- a/k8s/charts/clean-architecture/templates/postgresql/service.yaml
+++ b/k8s/charts/clean-architecture/templates/postgresql/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clean-architecture.postgresql.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.postgresql.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.postgresql.service.type }}
+  ports:
+    - port: {{ .Values.postgresql.service.port }}
+      targetPort: tcp-postgresql
+      protocol: TCP
+      name: tcp-postgresql
+  selector:
+    {{- include "clean-architecture.postgresql.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/charts/clean-architecture/templates/postgresql/statefulset.yaml
+++ b/k8s/charts/clean-architecture/templates/postgresql/statefulset.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "clean-architecture.postgresql.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.postgresql.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "clean-architecture.postgresql.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "clean-architecture.postgresql.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clean-architecture.postgresql.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: tcp-postgresql
+              containerPort: {{ .Values.postgresql.port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clean-architecture.fullname" . }}-secrets
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.username | quote }}
+                - -d
+                - {{ .Values.postgresql.database | quote }}
+            initialDelaySeconds: {{ .Values.postgresql.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.postgresql.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.postgresql.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.postgresql.probes.liveness.failureThreshold }}
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.username | quote }}
+                - -d
+                - {{ .Values.postgresql.database | quote }}
+            initialDelaySeconds: {{ .Values.postgresql.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.postgresql.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.postgresql.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.postgresql.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgresql.persistence.accessModes | nindent 10 }}
+        {{- if .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size | quote }}
+  {{- else }}
+      volumes:
+        - name: data
+          emptyDir: {}
+  {{- end }}
+{{- end }}

--- a/k8s/charts/clean-architecture/templates/secrets.yaml
+++ b/k8s/charts/clean-architecture/templates/secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clean-architecture.fullname" . }}-secrets
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.labels" . | nindent 4 }}
+  annotations:
+    # When using an external secret manager (e.g., External Secrets Operator,
+    # Sealed Secrets, or Vault), replace this Secret resource with the
+    # appropriate ExternalSecret or SealedSecret resource.
+    helm.sh/hook: pre-install,pre-upgrade
+type: Opaque
+data:
+  {{- if .Values.postgresql.password }}
+  POSTGRES_PASSWORD: {{ .Values.postgresql.password | b64enc | quote }}
+  {{- else }}
+  # Password must be provided via --set postgresql.password=... or an external secret manager.
+  # This placeholder will cause authentication failures if not overridden.
+  POSTGRES_PASSWORD: {{ "" | b64enc | quote }}
+  {{- end }}

--- a/k8s/charts/clean-architecture/templates/wallet-app/deployment.yaml
+++ b/k8s/charts/clean-architecture/templates/wallet-app/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clean-architecture.walletApp.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.walletApp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.walletApp.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "clean-architecture.walletApp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clean-architecture.walletApp.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.walletApp.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: wallet-app
+          image: "{{ .Values.walletApp.image.repository }}:{{ .Values.walletApp.image.tag }}"
+          imagePullPolicy: {{ .Values.walletApp.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.walletApp.containerPort }}
+              protocol: TCP
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: {{ .Values.walletApp.environment | quote }}
+            - name: ASPNETCORE_URLS
+              value: "http://+:{{ .Values.walletApp.containerPort }}"
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.walletApp.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.walletApp.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.walletApp.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.walletApp.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.walletApp.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.walletApp.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.walletApp.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.walletApp.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.walletApp.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.walletApp.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.walletApp.resources | nindent 12 }}

--- a/k8s/charts/clean-architecture/templates/wallet-app/ingress.yaml
+++ b/k8s/charts/clean-architecture/templates/wallet-app/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.walletApp.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "clean-architecture.walletApp.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.walletApp.labels" . | nindent 4 }}
+  {{- with .Values.walletApp.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.walletApp.ingress.className }}
+  ingressClassName: {{ .Values.walletApp.ingress.className }}
+  {{- end }}
+  {{- if .Values.walletApp.ingress.tls }}
+  tls:
+    {{- range .Values.walletApp.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.walletApp.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "clean-architecture.walletApp.fullname" $ }}
+                port:
+                  number: {{ $.Values.walletApp.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/charts/clean-architecture/templates/wallet-app/service.yaml
+++ b/k8s/charts/clean-architecture/templates/wallet-app/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clean-architecture.walletApp.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "clean-architecture.walletApp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.walletApp.service.type }}
+  ports:
+    - port: {{ .Values.walletApp.service.port }}
+      targetPort: {{ .Values.walletApp.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "clean-architecture.walletApp.selectorLabels" . | nindent 4 }}

--- a/k8s/charts/clean-architecture/values.production.yaml
+++ b/k8s/charts/clean-architecture/values.production.yaml
@@ -1,0 +1,74 @@
+# Production environment overrides
+
+namespace: clean-architecture-production
+
+accountsApi:
+  replicaCount: 3
+  image:
+    tag: "stable"
+    pullPolicy: Always
+  environment: Production
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+  ingress:
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      nginx.ingress.kubernetes.io/rate-limit: "100"
+      nginx.ingress.kubernetes.io/rate-limit-window: "1m"
+    hosts:
+      - host: app.example.com
+        paths:
+          - path: /accounts-api
+            pathType: Prefix
+    tls:
+      - secretName: clean-architecture-prod-tls
+        hosts:
+          - app.example.com
+
+walletApp:
+  replicaCount: 3
+  image:
+    tag: "stable"
+    pullPolicy: Always
+  environment: Production
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  ingress:
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    hosts:
+      - host: app.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: clean-architecture-prod-tls
+        hosts:
+          - app.example.com
+
+postgresql:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  persistence:
+    size: 50Gi

--- a/k8s/charts/clean-architecture/values.staging.yaml
+++ b/k8s/charts/clean-architecture/values.staging.yaml
@@ -1,0 +1,66 @@
+# Staging environment overrides
+
+namespace: clean-architecture-staging
+
+accountsApi:
+  replicaCount: 1
+  image:
+    tag: "staging"
+  environment: Staging
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  autoscaling:
+    enabled: false
+  ingress:
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-staging
+    hosts:
+      - host: staging.app.example.com
+        paths:
+          - path: /accounts-api
+            pathType: Prefix
+    tls:
+      - secretName: clean-architecture-staging-tls
+        hosts:
+          - staging.app.example.com
+
+walletApp:
+  replicaCount: 1
+  image:
+    tag: "staging"
+  environment: Staging
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 125m
+      memory: 128Mi
+  ingress:
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-staging
+    hosts:
+      - host: staging.app.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: clean-architecture-staging-tls
+        hosts:
+          - staging.app.example.com
+
+postgresql:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 512Mi
+  persistence:
+    size: 5Gi

--- a/k8s/charts/clean-architecture/values.yaml
+++ b/k8s/charts/clean-architecture/values.yaml
@@ -1,0 +1,151 @@
+# Default values for clean-architecture.
+# This is a YAML-formatted file.
+
+nameOverride: ""
+fullnameOverride: ""
+
+namespace: clean-architecture
+
+# -- Accounts API configuration
+accountsApi:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/atypical-consulting/accounts-api
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+  containerPort: 8080
+  basePath: /accounts-api
+  environment: Production
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  probes:
+    liveness:
+      path: /health
+      initialDelaySeconds: 15
+      periodSeconds: 20
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+  ingress:
+    enabled: true
+    className: nginx
+    annotations: {}
+    hosts:
+      - host: app.example.com
+        paths:
+          - path: /accounts-api
+            pathType: Prefix
+    tls:
+      - secretName: clean-architecture-tls
+        hosts:
+          - app.example.com
+
+# -- Wallet App (Blazor) configuration
+walletApp:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/atypical-consulting/wallet-app
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+  containerPort: 8080
+  environment: Production
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  probes:
+    liveness:
+      path: /
+      initialDelaySeconds: 10
+      periodSeconds: 20
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      path: /
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+  ingress:
+    enabled: true
+    className: nginx
+    annotations: {}
+    hosts:
+      - host: app.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: clean-architecture-tls
+        hosts:
+          - app.example.com
+
+# -- PostgreSQL configuration
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "17"
+    pullPolicy: IfNotPresent
+  port: 5432
+  database: Accounts
+  username: postgres
+  # Password is stored in a Kubernetes Secret, not here.
+  # Set via --set postgresql.password=... or external secret manager.
+  password: ""
+  service:
+    type: ClusterIP
+    port: 5432
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+  probes:
+    liveness:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6


### PR DESCRIPTION
## Summary

- Adds a complete Helm chart (`k8s/charts/clean-architecture/`) for deploying the full application stack to Kubernetes
- Includes Accounts API (Deployment + HPA + Ingress), Wallet App (Deployment + Ingress), and PostgreSQL (StatefulSet with PVC)
- Provides environment-specific values files for staging and production with appropriate resource tuning

## What's included

| Component | Resources |
|-----------|-----------|
| **Accounts API** | Deployment, Service, Ingress (TLS), HPA (CPU/memory) |
| **Wallet App** | Deployment, Service, Ingress (TLS) |
| **PostgreSQL** | StatefulSet, Service, PVC (persistent storage) |
| **Shared** | Namespace, ConfigMap, Secrets, `_helpers.tpl` |

### Key features
- **Health probes**: Accounts API uses `/health` endpoint; PostgreSQL uses `pg_isready`; Wallet App uses `/`
- **HPA**: Scales API pods on CPU (70%) and memory (80%) thresholds, 2-10 replicas (default)
- **TLS**: Ingress configured with TLS secret references, ready for cert-manager
- **Secrets**: Stored in Kubernetes Secrets (base64), designed for external secret manager integration -- no hardcoded passwords
- **Environment values**: `values.staging.yaml` (minimal resources, no HPA) and `values.production.yaml` (higher limits, aggressive scaling, rate limiting)
- **Resource limits**: All containers have CPU/memory requests and limits

### Usage
```bash
# Default install
helm install clean-arch k8s/charts/clean-architecture/ --set postgresql.password=<password>

# Staging
helm install clean-arch k8s/charts/clean-architecture/ -f k8s/charts/clean-architecture/values.staging.yaml --set postgresql.password=<password>

# Production
helm install clean-arch k8s/charts/clean-architecture/ -f k8s/charts/clean-architecture/values.production.yaml --set postgresql.password=<password>
```

## Test plan

- [ ] `helm template` renders all manifests without errors
- [ ] `helm install --dry-run` validates against a Kubernetes cluster
- [ ] Health checks and readiness probes point to correct endpoints
- [ ] Ingress routes `/accounts-api` to Accounts API and `/` to Wallet App
- [ ] Secrets are not hardcoded -- password must be provided at install time
- [ ] HPA targets the Accounts API Deployment with correct CPU/memory metrics

Fixes #17