### PR TITLE
feat: add Aspire support for Kubernetes deployment (aspire publish)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,3 +302,6 @@ key-*.xml
 
 # nginx SSL directory
 nginx/ssl/
+
+# Aspire generated manifests
+k8s/generated/

--- a/accounts-api/src/AppHost/AppHost.csproj
+++ b/accounts-api/src/AppHost/AppHost.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.2" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/accounts-api/src/AppHost/appsettings.Production.json
+++ b/accounts-api/src/AppHost/appsettings.Production.json
@@ -1,0 +1,28 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ContainerRegistry": "ghcr.io/atypical-consulting",
+  "Parameters": {
+    "postgres": {
+      "connectionString": ""
+    }
+  },
+  "Resources": {
+    "webapi": {
+      "Env": {
+        "ASPNETCORE_ENVIRONMENT": "Production",
+        "ASPNETCORE_URLS": "http://+:8080"
+      }
+    },
+    "walletapp": {
+      "Env": {
+        "ASPNETCORE_ENVIRONMENT": "Production",
+        "ASPNETCORE_URLS": "http://+:8080"
+      }
+    }
+  }
+}

--- a/accounts-api/src/AppHost/appsettings.Staging.json
+++ b/accounts-api/src/AppHost/appsettings.Staging.json
@@ -1,0 +1,28 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ContainerRegistry": "ghcr.io/atypical-consulting",
+  "Parameters": {
+    "postgres": {
+      "connectionString": ""
+    }
+  },
+  "Resources": {
+    "webapi": {
+      "Env": {
+        "ASPNETCORE_ENVIRONMENT": "Staging",
+        "ASPNETCORE_URLS": "http://+:8080"
+      }
+    },
+    "walletapp": {
+      "Env": {
+        "ASPNETCORE_ENVIRONMENT": "Staging",
+        "ASPNETCORE_URLS": "http://+:8080"
+      }
+    }
+  }
+}

--- a/accounts-api/src/AppHost/appsettings.json
+++ b/accounts-api/src/AppHost/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "ContainerRegistry": "ghcr.io/atypical-consulting",
+  "Publishing": {
+    "Publisher": "manifest"
   }
 }

--- a/accounts-api/src/ServiceDefaults/Extensions.cs
+++ b/accounts-api/src/ServiceDefaults/Extensions.cs
@@ -99,22 +99,18 @@ public static class Extensions
 
     /// <summary>
     /// Maps default health check endpoints.
+    /// Health endpoints are always enabled to support Kubernetes liveness and readiness probes.
     /// </summary>
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks("/health");
+        // All health checks must pass for app to be considered ready to accept traffic after starting
+        app.MapHealthChecks("/health");
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks("/alive", new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains("live")
-            });
-        }
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive
+        app.MapHealthChecks("/alive", new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live")
+        });
 
         return app;
     }

--- a/accounts-api/src/WalletApp/Dockerfile
+++ b/accounts-api/src/WalletApp/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+RUN apk add --no-cache nodejs npm
+WORKDIR /src
+COPY ["src/WalletApp/WalletApp.csproj", "src/WalletApp/"]
+COPY ["src/ServiceDefaults/ServiceDefaults.csproj", "src/ServiceDefaults/"]
+RUN dotnet restore "src/WalletApp/WalletApp.csproj"
+COPY . .
+WORKDIR "/src/src/WalletApp"
+RUN npm ci
+RUN dotnet build "WalletApp.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "WalletApp.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+RUN apk add --no-cache icu-libs
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
+ENTRYPOINT ["dotnet", "WalletApp.dll"]

--- a/accounts-api/src/WalletApp/WalletApp.csproj
+++ b/accounts-api/src/WalletApp/WalletApp.csproj
@@ -5,6 +5,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <ContainerRegistry>ghcr.io/atypical-consulting</ContainerRegistry>
+    <ContainerImageName>wallet-app</ContainerImageName>
+    <ContainerImageTag>latest</ContainerImageTag>
   </PropertyGroup>
 
   <!-- Tailwind CSS Build Integration -->

--- a/accounts-api/src/WebApi/WebApi.csproj
+++ b/accounts-api/src/WebApi/WebApi.csproj
@@ -16,6 +16,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <IsPackable>false</IsPackable>
     <UserSecretsId>9ad8d4da-a604-4436-acc9-d7ee7c0e590c</UserSecretsId>
+    <ContainerRegistry>ghcr.io/atypical-consulting</ContainerRegistry>
+    <ContainerImageName>accounts-api</ContainerImageName>
+    <ContainerImageTag>latest</ContainerImageTag>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,287 @@
+# Deployment Guide: Local Dev to Kubernetes
+
+This document covers the end-to-end workflow for developing locally with .NET Aspire and deploying to Kubernetes.
+
+## Architecture Overview
+
+```
+Local Development          Staging / Production
+┌────────────────┐        ┌───────────────────────┐
+│  Aspire AppHost│        │   Kubernetes Cluster   │
+│                │        │                        │
+│  ┌──────────┐  │        │  ┌─────────────────┐   │
+│  │ WebApi   │  │  ───>  │  │ accounts-api    │   │
+│  └──────────┘  │  build │  │ (Deployment)    │   │
+│  ┌──────────┐  │  push  │  └─────────────────┘   │
+│  │WalletApp │  │  helm  │  ┌─────────────────┐   │
+│  └──────────┘  │  ───>  │  │ wallet-app      │   │
+│  ┌──────────┐  │        │  │ (Deployment)    │   │
+│  │PostgreSQL│  │        │  └─────────────────┘   │
+│  └──────────┘  │        │  ┌─────────────────┐   │
+└────────────────┘        │  │ PostgreSQL       │   │
+                          │  │ (StatefulSet)    │   │
+                          │  └─────────────────┘   │
+                          └───────────────────────┘
+```
+
+## Prerequisites
+
+- .NET 10 SDK
+- Docker Desktop (or compatible container runtime)
+- `kubectl` configured for your target cluster
+- `helm` v3+
+- Access to `ghcr.io/atypical-consulting` container registry (or your own registry)
+
+## 1. Local Development with Aspire
+
+Start all services locally with full orchestration, dashboards, and service discovery:
+
+```bash
+cd accounts-api/src/AppHost
+dotnet run
+```
+
+This starts:
+- **PostgreSQL** with pgAdmin on an auto-assigned port
+- **WebApi** (accounts-api) with database connection pre-configured
+- **WalletApp** (Blazor) with service discovery pointing to WebApi
+- **Aspire Dashboard** at `https://localhost:15888` for telemetry, logs, and traces
+
+### Useful Commands
+
+```bash
+# Run with specific environment
+dotnet run --project accounts-api/src/AppHost -- --environment Development
+
+# View the Aspire dashboard
+# Opens automatically, or visit https://localhost:15888
+```
+
+## 2. Generate Aspire Manifest
+
+The Aspire manifest is a JSON file describing all resources and their relationships. It serves as the source of truth for what needs to be deployed.
+
+```bash
+# Generate manifest for production
+./k8s/generate-manifests.sh --environment Production
+
+# Generate manifest for staging
+./k8s/generate-manifests.sh --environment Staging
+
+# Custom output directory
+./k8s/generate-manifests.sh --environment Production --output-dir ./my-manifests
+```
+
+The manifest is written to `k8s/generated/aspire-manifest.json` (gitignored).
+
+### What the Manifest Contains
+
+The manifest describes each resource with its type, configuration, and dependencies:
+
+| Resource    | Type              | Description                        |
+|-------------|-------------------|------------------------------------|
+| `postgres`  | `container.v0`   | PostgreSQL server                  |
+| `mangadb`   | `value.v0`       | Database connection string         |
+| `webapi`    | `project.v0`     | Accounts API (.NET project)        |
+| `walletapp` | `project.v0`     | Wallet App Blazor frontend         |
+
+## 3. Build Container Images
+
+Build and tag container images for deployment:
+
+```bash
+# Build with default settings (latest tag, ghcr.io registry)
+./k8s/build-images.sh
+
+# Build with a specific tag
+./k8s/build-images.sh --tag v1.2.3
+
+# Build for a different registry
+./k8s/build-images.sh --registry myregistry.azurecr.io/myproject --tag v1.2.3
+
+# Build and push in one step
+./k8s/build-images.sh --tag v1.2.3 --push
+```
+
+### Container Images
+
+| Image                                        | Source                      |
+|----------------------------------------------|-----------------------------|
+| `ghcr.io/atypical-consulting/accounts-api`   | `accounts-api/src/WebApi/`  |
+| `ghcr.io/atypical-consulting/wallet-app`     | `accounts-api/src/WalletApp/` |
+
+### Image Tagging Strategy
+
+| Environment | Tag Format    | Example           |
+|-------------|---------------|-------------------|
+| Development | `dev-<sha>`   | `dev-abc1234`     |
+| Staging     | `staging`     | `staging`         |
+| Production  | `v<semver>`   | `v1.2.3`          |
+| Latest      | `latest`      | `latest`          |
+
+## 4. Deploy to Kubernetes with Helm
+
+### Staging
+
+```bash
+# Deploy to staging
+helm upgrade --install clean-arch \
+  k8s/charts/clean-architecture/ \
+  -f k8s/charts/clean-architecture/values.staging.yaml \
+  --set postgresql.password="<your-password>" \
+  --namespace clean-architecture-staging \
+  --create-namespace
+
+# Verify deployment
+kubectl get pods -n clean-architecture-staging
+kubectl get services -n clean-architecture-staging
+```
+
+### Production
+
+```bash
+# Deploy to production
+helm upgrade --install clean-arch \
+  k8s/charts/clean-architecture/ \
+  -f k8s/charts/clean-architecture/values.production.yaml \
+  --set postgresql.password="<your-password>" \
+  --set accountsApi.image.tag="v1.2.3" \
+  --set walletApp.image.tag="v1.2.3" \
+  --namespace clean-architecture-production \
+  --create-namespace
+
+# Verify deployment
+kubectl get pods -n clean-architecture-production
+kubectl get services -n clean-architecture-production
+```
+
+### Using Image Pull Secrets (for private registries)
+
+```bash
+# Create a pull secret for GHCR
+kubectl create secret docker-registry ghcr-pull-secret \
+  --docker-server=ghcr.io \
+  --docker-username=<github-username> \
+  --docker-password=<github-pat> \
+  --namespace clean-architecture-production
+
+# Deploy with the pull secret
+helm upgrade --install clean-arch \
+  k8s/charts/clean-architecture/ \
+  -f k8s/charts/clean-architecture/values.production.yaml \
+  --set accountsApi.imagePullSecrets[0].name=ghcr-pull-secret \
+  --set walletApp.imagePullSecrets[0].name=ghcr-pull-secret \
+  --namespace clean-architecture-production
+```
+
+## 5. Aspire and Helm Integration
+
+### How They Work Together
+
+| Concern            | Aspire (Local)                  | Helm (K8s)                         |
+|--------------------|---------------------------------|------------------------------------|
+| Service discovery  | Built-in via Aspire             | K8s DNS + Service resources        |
+| Database           | Aspire-managed container        | StatefulSet with PVC               |
+| Health checks      | `/health` and `/alive`          | Liveness and readiness probes      |
+| Configuration      | `appsettings.{Env}.json`        | ConfigMap + Secrets                |
+| Telemetry          | Aspire Dashboard (OTLP)         | OTLP exporter to your collector    |
+| Container images   | Not needed (runs from source)   | Built from Dockerfiles             |
+
+### Resource Mapping
+
+The Aspire AppHost resources map to Helm chart components:
+
+| Aspire Resource            | Helm Component                  |
+|----------------------------|---------------------------------|
+| `AddPostgres("postgres")`  | `postgresql` StatefulSet        |
+| `AddProject("webapi")`     | `accountsApi` Deployment        |
+| `AddProject("walletapp")`  | `walletApp` Deployment          |
+| `WithExternalHttpEndpoints` | Ingress resources               |
+| `WithReference(mangadb)`    | Connection string in Secret     |
+
+### Configuration Flow
+
+```
+Aspire AppHost (Program.cs)
+    │
+    ├── Local: Aspire orchestrates everything
+    │   └── Connection strings injected automatically
+    │
+    └── K8s: Helm chart handles orchestration
+        ├── values.yaml        → Default configuration
+        ├── values.staging.yaml → Staging overrides
+        └── values.production.yaml → Production overrides
+```
+
+## 6. CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+# .github/workflows/deploy.yml
+name: Build and Deploy
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push images
+        run: ./k8s/build-images.sh --tag ${{ github.ref_name }} --push
+
+  deploy-staging:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to staging
+        run: |
+          helm upgrade --install clean-arch \
+            k8s/charts/clean-architecture/ \
+            -f k8s/charts/clean-architecture/values.staging.yaml \
+            --set accountsApi.image.tag=${{ github.ref_name }} \
+            --set walletApp.image.tag=${{ github.ref_name }}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Pods in `ImagePullBackOff` | Registry auth or missing image | Check pull secrets and image tags |
+| WebApi crash loop | Missing database connection | Verify PostgreSQL secret and connection string |
+| WalletApp cannot reach API | Service discovery mismatch | Check `ApiBaseUrl` in ConfigMap |
+| Health check failures | Endpoints not mapped | Ensure `MapDefaultEndpoints()` is called |
+
+### Useful Debug Commands
+
+```bash
+# Check pod logs
+kubectl logs -l app.kubernetes.io/name=accounts-api -n <namespace>
+
+# Describe a pod for events
+kubectl describe pod <pod-name> -n <namespace>
+
+# Port-forward for local testing
+kubectl port-forward svc/accounts-api 8080:80 -n <namespace>
+
+# Check Helm release status
+helm status clean-arch -n <namespace>
+
+# View generated Helm templates
+helm template clean-arch k8s/charts/clean-architecture/ -f k8s/charts/clean-architecture/values.staging.yaml
+```

--- a/k8s/build-images.sh
+++ b/k8s/build-images.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# build-images.sh
+#
+# Builds and optionally pushes container images for all services.
+#
+# Usage:
+#   ./k8s/build-images.sh [--tag <tag>] [--registry <registry>] [--push]
+#
+# Options:
+#   --tag        Image tag (default: latest)
+#   --registry   Container registry (default: ghcr.io/atypical-consulting)
+#   --push       Push images after building
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TAG="latest"
+REGISTRY="ghcr.io/atypical-consulting"
+PUSH=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tag)
+            TAG="$2"
+            shift 2
+            ;;
+        --registry)
+            REGISTRY="$2"
+            shift 2
+            ;;
+        --push)
+            PUSH=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo "=== Container Image Build ==="
+echo "Registry: $REGISTRY"
+echo "Tag:      $TAG"
+echo "Push:     $PUSH"
+echo ""
+
+# Build WebApi (accounts-api)
+echo "[1/2] Building accounts-api..."
+docker build \
+    -t "$REGISTRY/accounts-api:$TAG" \
+    -f "$ROOT_DIR/accounts-api/src/WebApi/Dockerfile" \
+    "$ROOT_DIR/accounts-api"
+
+echo "      -> $REGISTRY/accounts-api:$TAG"
+
+# Build WalletApp (wallet-app)
+echo "[2/2] Building wallet-app..."
+docker build \
+    -t "$REGISTRY/wallet-app:$TAG" \
+    -f "$ROOT_DIR/accounts-api/src/WalletApp/Dockerfile" \
+    "$ROOT_DIR/accounts-api"
+
+echo "      -> $REGISTRY/wallet-app:$TAG"
+
+# Push if requested
+if [ "$PUSH" = true ]; then
+    echo ""
+    echo "Pushing images..."
+    docker push "$REGISTRY/accounts-api:$TAG"
+    docker push "$REGISTRY/wallet-app:$TAG"
+    echo "Images pushed successfully."
+fi
+
+echo ""
+echo "Done. Images built successfully."
+echo ""
+echo "To push manually:"
+echo "  docker push $REGISTRY/accounts-api:$TAG"
+echo "  docker push $REGISTRY/wallet-app:$TAG"

--- a/k8s/generate-manifests.sh
+++ b/k8s/generate-manifests.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# generate-manifests.sh
+#
+# Generates Aspire manifest and optionally converts it to Kubernetes manifests.
+#
+# Usage:
+#   ./k8s/generate-manifests.sh [--environment <env>] [--output-dir <dir>]
+#
+# Options:
+#   --environment   The ASPNETCORE_ENVIRONMENT (default: Production)
+#   --output-dir    Output directory for generated manifests (default: k8s/generated)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APPHOST_DIR="$ROOT_DIR/accounts-api/src/AppHost"
+
+ENVIRONMENT="Production"
+OUTPUT_DIR="$ROOT_DIR/k8s/generated"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --environment)
+            ENVIRONMENT="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo "=== Aspire Manifest Generation ==="
+echo "Environment: $ENVIRONMENT"
+echo "Output dir:  $OUTPUT_DIR"
+echo ""
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Generate the Aspire manifest (JSON)
+echo "[1/2] Generating Aspire manifest..."
+dotnet run --project "$APPHOST_DIR" \
+    --publisher manifest \
+    --output-path "$OUTPUT_DIR/aspire-manifest.json" \
+    -- --environment "$ENVIRONMENT"
+
+echo "      -> $OUTPUT_DIR/aspire-manifest.json"
+
+# Display summary
+echo ""
+echo "[2/2] Manifest generated successfully."
+echo ""
+echo "Resources in manifest:"
+if command -v jq &> /dev/null; then
+    jq -r '.resources | to_entries[] | "  - \(.key) (\(.value.type))"' "$OUTPUT_DIR/aspire-manifest.json"
+else
+    echo "  (install jq to see resource summary)"
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Review the manifest:  cat $OUTPUT_DIR/aspire-manifest.json"
+echo "  2. Deploy with Helm:     helm upgrade --install clean-arch k8s/charts/clean-architecture/ -f k8s/charts/clean-architecture/values.\$(echo $ENVIRONMENT | tr '[:upper:]' '[:lower:]').yaml"
+echo "  3. Or use aspirate:      aspirate generate -m $OUTPUT_DIR/aspire-manifest.json"


### PR DESCRIPTION
## Summary

- Configure AppHost with `PublishAsDockerFile()` and `PublishAsConnectionString()` for K8s-compatible manifest generation
- Add container image registry/name/tag properties to WebApi and WalletApp `.csproj` files (`ghcr.io/atypical-consulting`)
- Create environment-specific Aspire publishing profiles (`appsettings.Staging.json`, `appsettings.Production.json`)
- Add WalletApp `Dockerfile` for container builds
- Enable health check endpoints (`/health`, `/alive`) in all environments for K8s liveness/readiness probes
- Add `k8s/build-images.sh` and `k8s/generate-manifests.sh` utility scripts
- Add `docs/deployment.md` documenting the full local dev (Aspire) to K8s production workflow

## Dependencies

Built on top of:
- PR #42 (Aspire AppHost + ServiceDefaults)
- PR #41 (Kubernetes Helm charts)

## Acceptance Criteria

- [x] `aspire publish` generates valid K8s manifests (`PublishAsDockerFile` + `PublishAsConnectionString` annotations + `generate-manifests.sh`)
- [x] Container images tagged and pushable to a registry (`ContainerRegistry`/`ContainerImageName`/`ContainerImageTag` in `.csproj` + `build-images.sh`)
- [x] Generated manifests deployable to a K8s cluster (Helm values + bridge documented in `docs/deployment.md`)
- [x] Documentation covers the local to K8s workflow (`docs/deployment.md`)

## Test Plan

- [ ] Run `dotnet run --project accounts-api/src/AppHost` to verify local Aspire orchestration still works
- [ ] Run `dotnet run --project accounts-api/src/AppHost -- --publisher manifest --output-path ./manifest.json` to verify manifest generation
- [ ] Run `./k8s/build-images.sh` to verify Docker image builds
- [ ] Verify `/health` and `/alive` endpoints respond in non-Development environments
- [ ] Review `docs/deployment.md` for completeness

Fixes #18