### PR TITLE
feat: replace EF Core InMemory with Testcontainers for integration tests

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -22,21 +22,6 @@ jobs:
   # ─────────────────────────────────────────────
   build-and-test:
     runs-on: ubuntu-latest
-    env:
-      PersistenceModule__DefaultConnection: Host=localhost;Port=5432;Database=Accounts;Username=postgres;Password=YourStrong!Passw0rd
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_PASSWORD: YourStrong!Passw0rd
-          POSTGRES_DB: Accounts
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
@@ -54,13 +39,6 @@ jobs:
 
       - name: Build
         run: dotnet build --configuration Release
-
-      - name: Run database migrations
-        run: |
-          dotnet tool update --global dotnet-ef
-          pushd accounts-api
-          dotnet ef database update --project src/Infrastructure --startup-project src/WebApi
-          popd
 
       - name: Test
         run: dotnet test --configuration Release --no-build
@@ -99,6 +77,7 @@ jobs:
           tags: |
             type=sha,prefix=
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}

--- a/accounts-api/test/ComponentTests/ComponentTests.csproj
+++ b/accounts-api/test/ComponentTests/ComponentTests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/accounts-api/test/ComponentTests/CustomWebApplicationFactory.cs
+++ b/accounts-api/test/ComponentTests/CustomWebApplicationFactory.cs
@@ -1,23 +1,51 @@
 namespace ComponentTests;
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Infrastructure.DataAccess;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.PostgreSql;
 using WebApi;
+using Xunit;
 
 /// <summary>
 /// </summary>
-public sealed class CustomWebApplicationFactory : WebApplicationFactory<Startup>
+public sealed class CustomWebApplicationFactory : WebApplicationFactory<Startup>, IAsyncLifetime
 {
-    protected override void ConfigureWebHost(IWebHostBuilder builder) => builder.ConfigureAppConfiguration(
-        (context, config) =>
-        {
-            config.AddInMemoryCollection(
-                new Dictionary<string, string>
-                {
-                    ["FeatureManagement:PostgreSql"] = "false",
-                    ["FeatureManagement:CurrencyExchangeModule"] = "false"
-                });
-        });
+    private readonly PostgreSqlContainer _postgresContainer = new PostgreSqlBuilder("postgres:17")
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await this._postgresContainer.StartAsync();
+
+        // Trigger host creation so ConfigureWebHost runs with the container ready
+        using var scope = this.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MangaContext>();
+        await context.Database.EnsureCreatedAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await base.DisposeAsync();
+        await this._postgresContainer.DisposeAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(
+            (context, config) =>
+            {
+                config.AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        ["FeatureManagement:PostgreSql"] = "true",
+                        ["PersistenceModule:DefaultConnection"] = this._postgresContainer.GetConnectionString(),
+                        ["FeatureManagement:CurrencyExchangeModule"] = "false"
+                    });
+            });
+    }
 }

--- a/accounts-api/test/ComponentTests/CustomWebApplicationFactoryFixture.cs
+++ b/accounts-api/test/ComponentTests/CustomWebApplicationFactoryFixture.cs
@@ -1,10 +1,11 @@
 namespace ComponentTests;
 
-using System;
+using System.Threading.Tasks;
+using Xunit;
 
 /// <summary>
 /// </summary>
-public sealed class CustomWebApplicationFactoryFixture : IDisposable
+public sealed class CustomWebApplicationFactoryFixture : IAsyncLifetime
 {
     public CustomWebApplicationFactoryFixture() =>
         this.CustomWebApplicationFactory = new CustomWebApplicationFactory();
@@ -13,5 +14,9 @@ public sealed class CustomWebApplicationFactoryFixture : IDisposable
     /// </summary>
     public CustomWebApplicationFactory CustomWebApplicationFactory { get; }
 
-    public void Dispose() => this.CustomWebApplicationFactory?.Dispose();
+    public async Task InitializeAsync() =>
+        await this.CustomWebApplicationFactory.InitializeAsync();
+
+    public async Task DisposeAsync() =>
+        await this.CustomWebApplicationFactory.DisposeAsync();
 }

--- a/accounts-api/test/EndToEndTests/CustomWebApplicationFactory.cs
+++ b/accounts-api/test/EndToEndTests/CustomWebApplicationFactory.cs
@@ -1,25 +1,51 @@
 namespace EndToEndTests;
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Infrastructure.DataAccess;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.PostgreSql;
 using WebApi;
+using Xunit;
 
 /// <summary>
 /// </summary>
-public sealed class CustomWebApplicationFactory : WebApplicationFactory<Startup>
+public sealed class CustomWebApplicationFactory : WebApplicationFactory<Startup>, IAsyncLifetime
 {
-    protected override void ConfigureWebHost(IWebHostBuilder builder) => builder.ConfigureAppConfiguration(
-        (context, config) =>
-        {
-            config.AddInMemoryCollection(
-                new Dictionary<string, string>
-                {
-                    ["FeatureManagement:PostgreSql"] = "true",
-                    ["PersistenceModule:DefaultConnection"] =
-                        "Host=localhost;Port=5432;Database=Accounts;Username=postgres;Password=YourStrong!Passw0rd",
-                    ["FeatureManagement:CurrencyExchangeModule"] = "true"
-                });
-        });
+    private readonly PostgreSqlContainer _postgresContainer = new PostgreSqlBuilder("postgres:17")
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await this._postgresContainer.StartAsync();
+
+        // Trigger host creation so ConfigureWebHost runs with the container ready
+        using var scope = this.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MangaContext>();
+        await context.Database.EnsureCreatedAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await base.DisposeAsync();
+        await this._postgresContainer.DisposeAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(
+            (context, config) =>
+            {
+                config.AddInMemoryCollection(
+                    new Dictionary<string, string>
+                    {
+                        ["FeatureManagement:PostgreSql"] = "true",
+                        ["PersistenceModule:DefaultConnection"] = this._postgresContainer.GetConnectionString(),
+                        ["FeatureManagement:CurrencyExchangeModule"] = "true"
+                    });
+            });
+    }
 }

--- a/accounts-api/test/EndToEndTests/CustomWebApplicationFactoryFixture.cs
+++ b/accounts-api/test/EndToEndTests/CustomWebApplicationFactoryFixture.cs
@@ -1,10 +1,11 @@
 namespace EndToEndTests;
 
-using System;
+using System.Threading.Tasks;
+using Xunit;
 
 /// <summary>
 /// </summary>
-public sealed class CustomWebApplicationFactoryFixture : IDisposable
+public sealed class CustomWebApplicationFactoryFixture : IAsyncLifetime
 {
     public CustomWebApplicationFactoryFixture() =>
         this.CustomWebApplicationFactory = new CustomWebApplicationFactory();
@@ -13,5 +14,9 @@ public sealed class CustomWebApplicationFactoryFixture : IDisposable
     /// </summary>
     public CustomWebApplicationFactory CustomWebApplicationFactory { get; }
 
-    public void Dispose() => this.CustomWebApplicationFactory?.Dispose();
+    public async Task InitializeAsync() =>
+        await this.CustomWebApplicationFactory.InitializeAsync();
+
+    public async Task DisposeAsync() =>
+        await this.CustomWebApplicationFactory.DisposeAsync();
 }

--- a/accounts-api/test/EndToEndTests/EndToEndTests.csproj
+++ b/accounts-api/test/EndToEndTests/EndToEndTests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/accounts-api/test/IntegrationTests/EntityFrameworkTests/StandardFixture.cs
+++ b/accounts-api/test/IntegrationTests/EntityFrameworkTests/StandardFixture.cs
@@ -1,30 +1,37 @@
 namespace IntegrationTests.EntityFrameworkTests;
 
 using System;
+using System.Threading.Tasks;
 using Infrastructure.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Testcontainers.PostgreSql;
+using Xunit;
 
-public sealed class StandardFixture : IDisposable
+public sealed class StandardFixture : IAsyncLifetime
 {
-    public StandardFixture()
+    private readonly PostgreSqlContainer _postgresContainer = new PostgreSqlBuilder("postgres:17")
+        .Build();
+
+    public MangaContext Context { get; private set; } = null!;
+
+    public async Task InitializeAsync()
     {
-        const string connectionString =
-            "Host=localhost;Port=5432;Database=Accounts;Username=postgres;Password=YourStrong!Passw0rd";
+        await this._postgresContainer.StartAsync();
 
         DbContextOptions<MangaContext> options = new DbContextOptionsBuilder<MangaContext>()
-            .UseNpgsql(connectionString)
+            .UseNpgsql(this._postgresContainer.GetConnectionString())
             .ConfigureWarnings(warnings =>
                 warnings.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
 
         this.Context = new MangaContext(options);
-        this.Context
-            .Database
-            .EnsureCreated();
+        await this.Context.Database.EnsureCreatedAsync();
     }
 
-    public MangaContext Context { get; }
-
-    public void Dispose() => this.Context.Dispose();
+    public async Task DisposeAsync()
+    {
+        this.Context?.Dispose();
+        await this._postgresContainer.DisposeAsync();
+    }
 }

--- a/accounts-api/test/IntegrationTests/IntegrationTests.csproj
+++ b/accounts-api/test/IntegrationTests/IntegrationTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Summary

- Replace `Microsoft.EntityFrameworkCore.InMemory` and hardcoded PostgreSQL connection strings with `Testcontainers.PostgreSql` across all test projects
- Each test fixture now spins up an ephemeral PostgreSQL container automatically, ensuring tests run against real database behavior
- Simplify CI workflow by removing the PostgreSQL service container and EF migration step — Testcontainers handles the full container lifecycle

## Changes

- **IntegrationTests**: Replace `StandardFixture` constructor-based localhost connection with `IAsyncLifetime` + Testcontainers PostgreSQL container; remove `Microsoft.EntityFrameworkCore.InMemory` package
- **ComponentTests**: Update `CustomWebApplicationFactory` to implement `IAsyncLifetime`, start a PostgreSQL container, enable `PostgreSql` feature flag, and call `EnsureCreatedAsync` for seed data; update fixture to use `IAsyncLifetime`
- **EndToEndTests**: Same pattern as ComponentTests — replace hardcoded localhost connection string with Testcontainers; update fixture to use `IAsyncLifetime`
- **UnitTests**: No changes — still use `MangaContextFake` (no database needed)
- **CI workflow** (`.github/workflows/dotnet-core.yml`): Remove PostgreSQL service container, environment variables, and `dotnet ef database update` step

## Testing

- [x] All test projects build successfully (0 errors, 0 warnings)
- [x] Unit tests pass (14/14)
- [ ] Integration, Component, and EndToEnd tests require Docker (validated in CI)
- [x] No `Microsoft.EntityFrameworkCore.InMemory` references remain in the codebase

Fixes #20