### PR TITLE
feat: add structured logging with Serilog and OpenTelemetry sink

### DIFF
--- a/accounts-api/src/Application/Application.csproj
+++ b/accounts-api/src/Application/Application.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
 

--- a/accounts-api/src/Application/UseCases/Deposit/DepositUseCase.cs
+++ b/accounts-api/src/Application/UseCases/Deposit/DepositUseCase.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Domain;
 using Domain.Credits;
 using Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
 using Services;
 
 /// <inheritdoc />
@@ -17,6 +18,7 @@ public sealed class DepositUseCase : IDepositUseCase
     private readonly IAccountFactory _accountFactory;
     private readonly IAccountRepository _accountRepository;
     private readonly ICurrencyExchange _currencyExchange;
+    private readonly ILogger<DepositUseCase> _logger;
     private readonly IUnitOfWork _unitOfWork;
     private IOutputPort _outputPort;
 
@@ -27,16 +29,19 @@ public sealed class DepositUseCase : IDepositUseCase
     /// <param name="unitOfWork">Unit Of Work.</param>
     /// <param name="accountFactory"></param>
     /// <param name="currencyExchange"></param>
+    /// <param name="logger"></param>
     public DepositUseCase(
         IAccountRepository accountRepository,
         IUnitOfWork unitOfWork,
         IAccountFactory accountFactory,
-        ICurrencyExchange currencyExchange)
+        ICurrencyExchange currencyExchange,
+        ILogger<DepositUseCase> logger)
     {
         this._accountRepository = accountRepository;
         this._unitOfWork = unitOfWork;
         this._accountFactory = accountFactory;
         this._currencyExchange = currencyExchange;
+        this._logger = logger;
         this._outputPort = new DepositPresenter();
     }
 
@@ -51,6 +56,10 @@ public sealed class DepositUseCase : IDepositUseCase
 
     private async Task Deposit(AccountId accountId, Money amount)
     {
+        this._logger.LogInformation(
+            "Processing deposit of {Amount} {Currency} to account {AccountId}",
+            amount.Amount, amount.Currency, accountId);
+
         IAccount account = await this._accountRepository
             .GetAccount(accountId)
             .ConfigureAwait(false);
@@ -68,10 +77,15 @@ public sealed class DepositUseCase : IDepositUseCase
             await this.Deposit(depositAccount, credit)
                 .ConfigureAwait(false);
 
+            this._logger.LogInformation(
+                "Deposit of {Amount} {Currency} completed for account {AccountId}",
+                convertedAmount.Amount, convertedAmount.Currency, accountId);
+
             this._outputPort.Ok(credit, depositAccount);
             return;
         }
 
+        this._logger.LogWarning("Deposit failed: account {AccountId} not found", accountId);
         this._outputPort.NotFound();
     }
 

--- a/accounts-api/src/Application/UseCases/GetAccount/GetAccountUseCase.cs
+++ b/accounts-api/src/Application/UseCases/GetAccount/GetAccountUseCase.cs
@@ -8,20 +8,26 @@ using System;
 using System.Threading.Tasks;
 using Domain;
 using Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
 
 /// <inheritdoc />
 public sealed class GetAccountUseCase : IGetAccountUseCase
 {
     private readonly IAccountRepository _accountRepository;
+    private readonly ILogger<GetAccountUseCase> _logger;
     private IOutputPort _outputPort;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="GetAccountUseCase" /> class.
     /// </summary>
     /// <param name="accountRepository">Account Repository.</param>
-    public GetAccountUseCase(IAccountRepository accountRepository)
+    /// <param name="logger"></param>
+    public GetAccountUseCase(
+        IAccountRepository accountRepository,
+        ILogger<GetAccountUseCase> logger)
     {
         this._accountRepository = accountRepository;
+        this._logger = logger;
         this._outputPort = new GetAccountPresenter();
     }
 
@@ -34,6 +40,8 @@ public sealed class GetAccountUseCase : IGetAccountUseCase
 
     private async Task GetAccountInternal(AccountId accountId)
     {
+        this._logger.LogDebug("Retrieving account {AccountId}", accountId);
+
         IAccount account = await this._accountRepository
             .GetAccount(accountId)
             .ConfigureAwait(false);
@@ -44,6 +52,7 @@ public sealed class GetAccountUseCase : IGetAccountUseCase
             return;
         }
 
+        this._logger.LogWarning("Account {AccountId} not found", accountId);
         this._outputPort.NotFound();
     }
 }

--- a/accounts-api/src/WebApi/Modules/Common/ActivityEnricher.cs
+++ b/accounts-api/src/WebApi/Modules/Common/ActivityEnricher.cs
@@ -1,0 +1,30 @@
+namespace WebApi.Modules.Common;
+
+using System.Diagnostics;
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+///     Enriches Serilog log events with OpenTelemetry trace and span IDs
+///     from the current <see cref="Activity" />, enabling correlation
+///     between logs and distributed traces in the Aspire dashboard.
+/// </summary>
+public sealed class ActivityEnricher : ILogEventEnricher
+{
+    /// <inheritdoc />
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        var activity = Activity.Current;
+        if (activity is null)
+        {
+            return;
+        }
+
+        logEvent.AddPropertyIfAbsent(
+            propertyFactory.CreateProperty("TraceId", activity.TraceId.ToHexString()));
+        logEvent.AddPropertyIfAbsent(
+            propertyFactory.CreateProperty("SpanId", activity.SpanId.ToHexString()));
+        logEvent.AddPropertyIfAbsent(
+            propertyFactory.CreateProperty("ParentSpanId", activity.ParentSpanId.ToHexString()));
+    }
+}

--- a/accounts-api/src/WebApi/WebApi.csproj
+++ b/accounts-api/src/WebApi/WebApi.csproj
@@ -48,6 +48,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Serilog structured logging -->
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.2" />
   </ItemGroup>
 

--- a/accounts-api/src/WebApi/appsettings.Development.json
+++ b/accounts-api/src/WebApi/appsettings.Development.json
@@ -1,10 +1,28 @@
 {
-    "Logging": {
-        "LogLevel": {
+    "Serilog": {
+        "MinimumLevel": {
             "Default": "Information",
-            "Microsoft": "Information",
-            "Microsoft.Hosting.Lifetime": "Information"
-        }
+            "Override": {
+                "Microsoft": "Information",
+                "Microsoft.Hosting.Lifetime": "Information",
+                "Microsoft.EntityFrameworkCore.Database.Command": "Information"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+                }
+            },
+            {
+                "Name": "OpenTelemetry",
+                "Args": {
+                    "endpoint": "http://localhost:18889",
+                    "protocol": "HttpProtobuf"
+                }
+            }
+        ]
     },
     "FeatureManagement": {
         "CloseAccount": true,

--- a/accounts-api/src/WebApi/appsettings.Production.json
+++ b/accounts-api/src/WebApi/appsettings.Production.json
@@ -1,10 +1,27 @@
 {
-    "Logging": {
-        "LogLevel": {
+    "Serilog": {
+        "MinimumLevel": {
             "Default": "Warning",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Warning"
-        }
+            "Override": {
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Warning",
+                "Application": "Information"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+                }
+            },
+            {
+                "Name": "OpenTelemetry",
+                "Args": {
+                    "protocol": "Grpc"
+                }
+            }
+        ]
     },
     "FeatureManagement": {
         "CloseAccount": true,

--- a/accounts-api/src/WebApi/appsettings.json
+++ b/accounts-api/src/WebApi/appsettings.json
@@ -1,9 +1,31 @@
 {
-    "Logging": {
-        "LogLevel": {
+    "Serilog": {
+        "Using": [
+            "Serilog.Sinks.Console",
+            "Serilog.Sinks.OpenTelemetry",
+            "Serilog.Enrichers.Environment"
+        ],
+        "MinimumLevel": {
             "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
+            "Override": {
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Information",
+                "Microsoft.EntityFrameworkCore": "Warning",
+                "System": "Warning"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console"
+            }
+        ],
+        "Enrich": [
+            "FromLogContext",
+            "WithMachineName",
+            "WithEnvironmentName"
+        ],
+        "Properties": {
+            "Application": "AccountsApi"
         }
     },
     "AllowedHosts": "*"

--- a/accounts-api/test/UnitTests/CloseAccount/CloseAccountTests.cs
+++ b/accounts-api/test/UnitTests/CloseAccount/CloseAccountTests.cs
@@ -9,6 +9,7 @@ using Domain;
 using Domain.Credits;
 using Domain.ValueObjects;
 using Infrastructure.DataAccess;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 public sealed class CloseAccountTests : IClassFixture<StandardFixture>
@@ -41,19 +42,23 @@ public sealed class CloseAccountTests : IClassFixture<StandardFixture>
         GetAccountPresenter getAccountPresenter = new GetAccountPresenter();
         CloseAccountPresenter closeAccountPresenter = new CloseAccountPresenter();
 
-        GetAccountUseCase getAccountUseCase = new GetAccountUseCase(this._fixture.AccountRepositoryFake);
+        GetAccountUseCase getAccountUseCase = new GetAccountUseCase(
+            this._fixture.AccountRepositoryFake,
+            NullLogger<GetAccountUseCase>.Instance);
 
         WithdrawUseCase withdrawUseCase = new WithdrawUseCase(
             this._fixture.AccountRepositoryFake,
             this._fixture.UnitOfWork,
             this._fixture.EntityFactory,
             this._fixture.TestUserService,
-            this._fixture.CurrencyExchangeFake);
+            this._fixture.CurrencyExchangeFake,
+            NullLogger<WithdrawUseCase>.Instance);
 
         CloseAccountUseCase sut = new CloseAccountUseCase(
             this._fixture.AccountRepositoryFake,
             this._fixture.TestUserService,
-            this._fixture.UnitOfWork);
+            this._fixture.UnitOfWork,
+            NullLogger<CloseAccountUseCase>.Instance);
 
         sut.SetOutputPort(closeAccountPresenter);
         getAccountUseCase.SetOutputPort(getAccountPresenter);

--- a/accounts-api/test/UnitTests/Deposit/DepositTests.cs
+++ b/accounts-api/test/UnitTests/Deposit/DepositTests.cs
@@ -6,6 +6,7 @@ using Application.UseCases.Deposit;
 using Domain.Credits;
 using Domain.ValueObjects;
 using Infrastructure.DataAccess;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 public sealed class DepositTests : IClassFixture<StandardFixture>
@@ -23,7 +24,8 @@ public sealed class DepositTests : IClassFixture<StandardFixture>
             this._fixture.AccountRepositoryFake,
             this._fixture.UnitOfWork,
             this._fixture.EntityFactory,
-            this._fixture.CurrencyExchangeFake);
+            this._fixture.CurrencyExchangeFake,
+            NullLogger<DepositUseCase>.Instance);
 
         sut.SetOutputPort(presenter);
 
@@ -47,7 +49,8 @@ public sealed class DepositTests : IClassFixture<StandardFixture>
             this._fixture.AccountRepositoryFake,
             this._fixture.UnitOfWork,
             this._fixture.EntityFactory,
-            this._fixture.CurrencyExchangeFake);
+            this._fixture.CurrencyExchangeFake,
+            NullLogger<DepositUseCase>.Instance);
 
         DepositValidationUseCase sut = new DepositValidationUseCase(
             depositUseCase, notification);

--- a/accounts-api/test/UnitTests/OpenAccount/OpenAccountTests.cs
+++ b/accounts-api/test/UnitTests/OpenAccount/OpenAccountTests.cs
@@ -2,6 +2,7 @@ namespace UnitTests.OpenAccount;
 
 using System.Threading.Tasks;
 using Application.UseCases.OpenAccount;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 public sealed class OpenAccountTests : IClassFixture<StandardFixture>
@@ -19,7 +20,8 @@ public sealed class OpenAccountTests : IClassFixture<StandardFixture>
             this._fixture.AccountRepositoryFake,
             this._fixture.UnitOfWork,
             this._fixture.TestUserService,
-            this._fixture.EntityFactory);
+            this._fixture.EntityFactory,
+            NullLogger<OpenAccountUseCase>.Instance);
 
         sut.SetOutputPort(presenter);
 

--- a/accounts-api/test/UnitTests/Transfer/TransferUseCaseTests.cs
+++ b/accounts-api/test/UnitTests/Transfer/TransferUseCaseTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Application.UseCases.Transfer;
 using Domain;
 using Infrastructure.DataAccess;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 public sealed class TransferUseCaseTests : IClassFixture<StandardFixture>
@@ -23,7 +24,8 @@ public sealed class TransferUseCaseTests : IClassFixture<StandardFixture>
             this._fixture.AccountRepositoryFake,
             this._fixture.UnitOfWork,
             this._fixture.EntityFactory,
-            this._fixture.CurrencyExchangeFake);
+            this._fixture.CurrencyExchangeFake,
+            NullLogger<TransferUseCase>.Instance);
 
         sut.SetOutputPort(presenter);
 

--- a/accounts-api/test/UnitTests/Withdraw/WithdrawTests.cs
+++ b/accounts-api/test/UnitTests/Withdraw/WithdrawTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Application.UseCases.Withdraw;
 using Domain;
 using Infrastructure.DataAccess;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 public sealed class WithdrawTests : IClassFixture<StandardFixture>
@@ -24,7 +25,8 @@ public sealed class WithdrawTests : IClassFixture<StandardFixture>
             this._fixture.UnitOfWork,
             this._fixture.EntityFactory,
             this._fixture.TestUserService,
-            this._fixture.CurrencyExchangeFake);
+            this._fixture.CurrencyExchangeFake,
+            NullLogger<WithdrawUseCase>.Instance);
 
         sut.SetOutputPort(presenter);
 


### PR DESCRIPTION
## Summary

- Integrate Serilog as the structured logging provider with OpenTelemetry sink for centralized log collection via the Aspire dashboard
- Add trace context enrichment (TraceId, SpanId, ParentSpanId) for correlation between logs and distributed traces
- Add meaningful structured log statements across all use cases in the Application layer

## Changes

### WebApi
- **Program.cs**: Configure Serilog via `UseSerilog()` with configuration-based setup, environment enrichment, and custom `ActivityEnricher` for OpenTelemetry trace correlation. Add `UseSerilogRequestLogging` middleware with request host, user agent, and user ID enrichment.
- **WebApi.csproj**: Add Serilog.AspNetCore (9.0.0), Serilog.Sinks.OpenTelemetry (4.1.1), Serilog.Formatting.Compact (3.0.0), and Serilog.Enrichers.Environment (3.0.1) packages.
- **ActivityEnricher.cs** (new): Custom Serilog enricher that adds TraceId, SpanId, and ParentSpanId from the current `System.Diagnostics.Activity` to every log event.
- **appsettings.json**: Replace `Logging` section with `Serilog` configuration including per-namespace log level overrides.
- **appsettings.Development.json**: Configure CompactJsonFormatter for structured JSON console output and OpenTelemetry sink (HttpProtobuf protocol, localhost:18889) for Aspire dashboard integration.
- **appsettings.Production.json**: Configure CompactJsonFormatter and OpenTelemetry sink (Grpc protocol) with stricter log levels.

### Application Layer
- **Application.csproj**: Add Microsoft.Extensions.Logging.Abstractions (10.0.0) for `ILogger<T>` dependency.
- **All use cases** (OpenAccount, CloseAccount, Deposit, Withdraw, Transfer, GetAccount, GetAccounts): Add `ILogger<T>` constructor parameter and structured log statements for key operations (start, success, warnings for not-found/denied scenarios).

### Tests
- **All unit tests**: Pass `NullLogger<T>.Instance` to updated use case constructors.

## Testing

- [x] Solution builds successfully (`dotnet build`)
- [x] All 14 unit tests pass (`dotnet test`)
- [ ] Verify logs appear in Aspire dashboard when running locally
- [ ] Verify structured JSON output in console during development
- [ ] Verify trace ID correlation between logs and traces

Fixes #21