### PR TITLE
fix: use preview version of Aspire.Hosting.Docker to unblock CI

### DIFF
--- a/accounts-api/src/AppHost/AppHost.csproj
+++ b/accounts-api/src/AppHost/AppHost.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.2" />
-    <PackageReference Include="Aspire.Hosting.Docker" Version="13.1.2" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.1.2-preview.1.26125.13" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes the CI/CD pipeline failure caused by a missing NuGet package version.

`Aspire.Hosting.Docker` has no stable `13.1.2` release — only preview versions exist on NuGet. Every CI run fails at restore with error `NU1102: Unable to find package Aspire.Hosting.Docker with version (>= 13.1.2)`.

Updated to the latest available version: `13.1.2-preview.1.26125.13`.

## Changes

- `accounts-api/src/AppHost/AppHost.csproj`: Updated `Aspire.Hosting.Docker` from `13.1.2` to `13.1.2-preview.1.26125.13`

## Testing

- `dotnet restore` succeeds locally with the updated version
- CI will validate on this PR push