### PR TITLE
fix: use DateTime.UtcNow for PostgreSQL timestamp compatibility

### DIFF
--- a/accounts-api/src/Application/UseCases/Deposit/DepositUseCase.cs
+++ b/accounts-api/src/Application/UseCases/Deposit/DepositUseCase.cs
@@ -72,7 +72,7 @@ public sealed class DepositUseCase : IDepositUseCase
                     .ConfigureAwait(false);
 
             Credit credit = this._accountFactory
-                .NewCredit(depositAccount, convertedAmount, DateTime.Now);
+                .NewCredit(depositAccount, convertedAmount, DateTime.UtcNow);
 
             await this.Deposit(depositAccount, credit)
                 .ConfigureAwait(false);

--- a/accounts-api/src/Application/UseCases/OpenAccount/OpenAccountUseCase.cs
+++ b/accounts-api/src/Application/UseCases/OpenAccount/OpenAccountUseCase.cs
@@ -57,7 +57,7 @@ public sealed class OpenAccountUseCase : IOpenAccountUseCase
             .NewAccount(externalUserId, amountToDeposit.Currency);
 
         Credit credit = this._accountFactory
-            .NewCredit(account, amountToDeposit, DateTime.Now);
+            .NewCredit(account, amountToDeposit, DateTime.UtcNow);
 
         await this.Deposit(account, credit)
             .ConfigureAwait(false);

--- a/accounts-api/src/Application/UseCases/Transfer/TransferUseCase.cs
+++ b/accounts-api/src/Application/UseCases/Transfer/TransferUseCase.cs
@@ -79,7 +79,7 @@ public sealed class TransferUseCase : ITransferUseCase
                     .ConfigureAwait(false);
 
             Debit debit = this._accountFactory
-                .NewDebit(withdrawAccount, localCurrencyAmount, DateTime.Now);
+                .NewDebit(withdrawAccount, localCurrencyAmount, DateTime.UtcNow);
 
             if (withdrawAccount.GetCurrentBalance().Subtract(debit.Amount).Amount < 0)
             {
@@ -99,7 +99,7 @@ public sealed class TransferUseCase : ITransferUseCase
                     .ConfigureAwait(false);
 
             Credit credit = this._accountFactory
-                .NewCredit(depositAccount, destinationCurrencyAmount, DateTime.Now);
+                .NewCredit(depositAccount, destinationCurrencyAmount, DateTime.UtcNow);
 
             await this.Deposit(depositAccount, credit)
                 .ConfigureAwait(false);

--- a/accounts-api/src/Application/UseCases/Withdraw/WithdrawUseCase.cs
+++ b/accounts-api/src/Application/UseCases/Withdraw/WithdrawUseCase.cs
@@ -79,7 +79,7 @@ public sealed class WithdrawUseCase : IWithdrawUseCase
                     .ConfigureAwait(false);
 
             Debit debit = this._accountFactory
-                .NewDebit(withdrawAccount, localCurrencyAmount, DateTime.Now);
+                .NewDebit(withdrawAccount, localCurrencyAmount, DateTime.UtcNow);
 
             if (withdrawAccount.GetCurrentBalance().Subtract(debit.Amount).Amount < 0)
             {

--- a/accounts-api/src/Infrastructure/DataAccess/MangaContextFake.cs
+++ b/accounts-api/src/Infrastructure/DataAccess/MangaContextFake.cs
@@ -22,14 +22,14 @@ public sealed class MangaContextFake
         Credit credit = new Credit(
             new CreditId(Guid.NewGuid()),
             SeedData.DefaultAccountId,
-            DateTime.Now,
+            DateTime.UtcNow,
             800,
             Currency.Dollar.Code);
 
         Debit debit = new Debit(
             new DebitId(Guid.NewGuid()),
             SeedData.DefaultAccountId,
-            DateTime.Now,
+            DateTime.UtcNow,
             300,
             Currency.Dollar.Code);
 

--- a/accounts-api/test/IntegrationTests/EntityFrameworkTests/AccountRepositoryTests.cs
+++ b/accounts-api/test/IntegrationTests/EntityFrameworkTests/AccountRepositoryTests.cs
@@ -29,7 +29,7 @@ public sealed class AccountRepositoryTests : IClassFixture<StandardFixture>
         Credit credit = new Credit(
             new CreditId(Guid.NewGuid()),
             account.AccountId,
-            DateTime.Now,
+            DateTime.UtcNow,
             400,
             "USD"
         );
@@ -70,7 +70,7 @@ public sealed class AccountRepositoryTests : IClassFixture<StandardFixture>
         Credit credit = new Credit(
             new CreditId(Guid.NewGuid()),
             account.AccountId,
-            DateTime.Now,
+            DateTime.UtcNow,
             400,
             "USD"
         );

--- a/accounts-api/test/UnitTests/CloseAccount/CloseAccountTests.cs
+++ b/accounts-api/test/UnitTests/CloseAccount/CloseAccountTests.cs
@@ -27,7 +27,7 @@ public sealed class CloseAccountTests : IClassFixture<StandardFixture>
 
         Credit credit = this._fixture
             .EntityFactory
-            .NewCredit(account, new Money(amount, Currency.Dollar), DateTime.Now);
+            .NewCredit(account, new Money(amount, Currency.Dollar), DateTime.UtcNow);
 
         account.Deposit(credit);
 


### PR DESCRIPTION
## Summary

Fixes all CI integration test failures caused by `DateTime.Now` producing `Kind=Local` timestamps, which Npgsql rejects when writing to PostgreSQL `timestamp with time zone` columns.

## Changes

- `accounts-api/src/Application/UseCases/Deposit/DepositUseCase.cs`: `DateTime.Now` → `DateTime.UtcNow`
- `accounts-api/src/Application/UseCases/Withdraw/WithdrawUseCase.cs`: `DateTime.Now` → `DateTime.UtcNow`
- `accounts-api/src/Application/UseCases/Transfer/TransferUseCase.cs`: `DateTime.Now` → `DateTime.UtcNow` (2 occurrences)
- `accounts-api/src/Application/UseCases/OpenAccount/OpenAccountUseCase.cs`: `DateTime.Now` → `DateTime.UtcNow`
- `accounts-api/src/Infrastructure/DataAccess/MangaContextFake.cs`: `DateTime.Now` → `DateTime.UtcNow` (2 occurrences)
- `accounts-api/test/IntegrationTests/EntityFrameworkTests/AccountRepositoryTests.cs`: `DateTime.Now` → `DateTime.UtcNow` (2 occurrences)
- `accounts-api/test/UnitTests/CloseAccount/CloseAccountTests.cs`: `DateTime.Now` → `DateTime.UtcNow`

## Testing

- Build passes with 0 errors
- No `DateTime.Now` references remain in the codebase
- Integration tests should now pass against real PostgreSQL (previously failing with `Cannot write DateTime with Kind=Local to PostgreSQL type 'timestamp with time zone'`)