### PR TITLE
fix: quote SQL identifiers in raw DELETE statements for PostgreSQL

### DIFF
--- a/accounts-api/src/Infrastructure/DataAccess/Repositories/AccountRepository.cs
+++ b/accounts-api/src/Infrastructure/DataAccess/Repositories/AccountRepository.cs
@@ -45,17 +45,17 @@ public sealed class AccountRepository : IAccountRepository
     {
         await this._context
             .Database
-            .ExecuteSqlRawAsync("DELETE FROM Debit WHERE AccountId=@p0", accountId.Id)
+            .ExecuteSqlRawAsync("DELETE FROM \"Debit\" WHERE \"AccountId\"=@p0", accountId.Id)
             .ConfigureAwait(false);
 
         await this._context
             .Database
-            .ExecuteSqlRawAsync("DELETE FROM Credit WHERE AccountId=@p0", accountId.Id)
+            .ExecuteSqlRawAsync("DELETE FROM \"Credit\" WHERE \"AccountId\"=@p0", accountId.Id)
             .ConfigureAwait(false);
 
         await this._context
             .Database
-            .ExecuteSqlRawAsync("DELETE FROM Account WHERE AccountId=@p0", accountId.Id)
+            .ExecuteSqlRawAsync("DELETE FROM \"Account\" WHERE \"AccountId\"=@p0", accountId.Id)
             .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## Summary

Fixes CI test failures (`relation "debit" does not exist`) caused by unquoted SQL identifiers in `AccountRepository.Delete`.

PostgreSQL lowercases unquoted identifiers, but EF Core's `ToTable("Debit")` creates tables with PascalCase names (quoted). The raw SQL `DELETE FROM Debit` was resolved by PostgreSQL as `DELETE FROM debit`, which doesn't exist.

## Changes

- `accounts-api/src/Infrastructure/DataAccess/Repositories/AccountRepository.cs`: Quoted all table and column names in raw SQL DELETE statements (`"Debit"`, `"Credit"`, `"Account"`, `"AccountId"`)

## Testing

- Build passes with 0 errors
- This fix resolves the `IntegrationTests.EntityFrameworkTests.AccountRepositoryTests.Delete` failure
- The ComponentTests `SunnyDayTests.Close` failure (500 error) should also resolve since it calls the same `Delete` code path