### PR TITLE
fix: use Alpine SDK image for WalletApp Dockerfile

### DIFF
--- a/accounts-api/src/WalletApp/Dockerfile
+++ b/accounts-api/src/WalletApp/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
 WORKDIR /app
 EXPOSE 8080
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 RUN apk add --no-cache nodejs npm
 WORKDIR /src
 COPY ["src/WalletApp/WalletApp.csproj", "src/WalletApp/"]


### PR DESCRIPTION
## Summary

- The WalletApp Dockerfile build stage used `mcr.microsoft.com/dotnet/sdk:10.0` (Debian-based) but called `apk add` (Alpine package manager), causing `apk: not found` (exit code 127)
- Changed to `mcr.microsoft.com/dotnet/sdk:10.0-alpine` to match the Alpine package manager usage
- The runtime base image (`aspnet:10.0-alpine`) was already Alpine — this makes the build stage consistent

## Root Cause

```
#10 [build  2/10] RUN apk add --no-cache nodejs npm
#10 0.126 /bin/sh: 1: apk: not found
ERROR: exit code: 127
```

## Test plan

- [ ] CI pipeline passes (the `build-images` job for `wallet-app` should succeed)
- [ ] Docker image builds and pushes to GHCR