### PR TITLE
feat: enable nullable reference types across all projects

### DIFF
--- a/accounts-api/Directory.Build.props
+++ b/accounts-api/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <Version>10.0.0</Version>
     <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/accounts-api/src/AppHost/AppHost.csproj
+++ b/accounts-api/src/AppHost/AppHost.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/accounts-api/src/Application/Application.csproj
+++ b/accounts-api/src/Application/Application.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <NoWarn>$(NoWarn);CA1062;1591</NoWarn>
-    <Nullable>enable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/accounts-api/src/Domain/Domain.csproj
+++ b/accounts-api/src/Domain/Domain.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <NoWarn>$(NoWarn);CA1062;1591</NoWarn>
-    <Nullable>enable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/accounts-api/src/Infrastructure/DataAccess/ContextFactory.cs
+++ b/accounts-api/src/Infrastructure/DataAccess/ContextFactory.cs
@@ -36,7 +36,7 @@ public sealed class ContextFactory : IDesignTimeDbContextFactory<MangaContext>
 
     private static string ReadDefaultConnectionStringFromAppSettings()
     {
-        string envName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        string envName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
 
         IConfigurationRoot configuration = new ConfigurationBuilder()
             .SetBasePath(Path.Combine(Directory.GetCurrentDirectory()))
@@ -45,7 +45,8 @@ public sealed class ContextFactory : IDesignTimeDbContextFactory<MangaContext>
             .AddEnvironmentVariables()
             .Build();
 
-        string connectionString = configuration.GetValue<string>("PersistenceModule:DefaultConnection");
+        string connectionString = configuration.GetValue<string>("PersistenceModule:DefaultConnection")
+            ?? throw new InvalidOperationException("Connection string 'PersistenceModule:DefaultConnection' not found.");
         return connectionString;
     }
 }

--- a/accounts-api/src/Infrastructure/DataAccess/Repositories/AccountRepository.cs
+++ b/accounts-api/src/Infrastructure/DataAccess/Repositories/AccountRepository.cs
@@ -62,16 +62,16 @@ public sealed class AccountRepository : IAccountRepository
     /// <inheritdoc />
     public async Task<IAccount> GetAccount(AccountId accountId)
     {
-        Account account = await this._context
+        Account? account = await this._context
             .Accounts
             .Where(e => e.AccountId == accountId)
             .Select(e => e)
             .SingleOrDefaultAsync()
             .ConfigureAwait(false);
 
-        if (account is Account findAccount)
+        if (account is not null)
         {
-            await this.LoadTransactions(findAccount)
+            await this.LoadTransactions(account)
                 .ConfigureAwait(false);
 
             return account;
@@ -94,16 +94,16 @@ public sealed class AccountRepository : IAccountRepository
 
     public async Task<IAccount> Find(AccountId accountId, string externalUserId)
     {
-        Account account = await this._context
+        Account? account = await this._context
             .Accounts
             .Where(e => e.ExternalUserId == externalUserId && e.AccountId == accountId)
             .Select(e => e)
             .SingleOrDefaultAsync()
             .ConfigureAwait(false);
 
-        if (account is Account findAccount)
+        if (account is not null)
         {
-            await this.LoadTransactions(findAccount)
+            await this.LoadTransactions(account)
                 .ConfigureAwait(false);
 
             return account;

--- a/accounts-api/src/Infrastructure/DataAccess/Repositories/AccountRepositoryFake.cs
+++ b/accounts-api/src/Infrastructure/DataAccess/Repositories/AccountRepositoryFake.cs
@@ -40,7 +40,7 @@ public sealed class AccountRepositoryFake : IAccountRepository
     /// <inheritdoc />
     public async Task Delete(AccountId accountId)
     {
-        Account accountOld = this._context
+        Account? accountOld = this._context
             .Accounts
             .SingleOrDefault(e => e.AccountId.Equals(accountId));
 
@@ -59,7 +59,7 @@ public sealed class AccountRepositoryFake : IAccountRepository
 
     public async Task<IAccount> Find(AccountId accountId, string externalUserId)
     {
-        Account account = this._context
+        Account? account = this._context
             .Accounts
             .Where(e => e.ExternalUserId == externalUserId && e.AccountId.Equals(accountId))
             .Select(e => e)
@@ -77,7 +77,7 @@ public sealed class AccountRepositoryFake : IAccountRepository
     /// <inheritdoc />
     public async Task<IAccount> GetAccount(AccountId accountId)
     {
-        Account account = this._context
+        Account? account = this._context
             .Accounts
             .SingleOrDefault(e => e.AccountId.Equals(accountId));
 
@@ -105,7 +105,7 @@ public sealed class AccountRepositoryFake : IAccountRepository
     /// <inheritdoc />
     public async Task Update(Account account, Credit credit)
     {
-        Account accountOld = this._context
+        Account? accountOld = this._context
             .Accounts
             .SingleOrDefault(e => e.AccountId.Equals(account.AccountId));
 
@@ -124,7 +124,7 @@ public sealed class AccountRepositoryFake : IAccountRepository
     /// <inheritdoc />
     public async Task Update(Account account, Debit debit)
     {
-        Account accountOld = this._context
+        Account? accountOld = this._context
             .Accounts
             .SingleOrDefault(e => e.AccountId.Equals(account.AccountId));
 

--- a/accounts-api/src/Infrastructure/Infrastructure.csproj
+++ b/accounts-api/src/Infrastructure/Infrastructure.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <NoWarn>$(NoWarn);CA1062;1591</NoWarn>
-    <Nullable>disable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/accounts-api/src/ServiceDefaults/ServiceDefaults.csproj
+++ b/accounts-api/src/ServiceDefaults/ServiceDefaults.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
   </PropertyGroup>
 

--- a/accounts-api/src/WalletApp/WalletApp.csproj
+++ b/accounts-api/src/WalletApp/WalletApp.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/accounts-api/src/WebApi/Modules/Common/BusinessMetrics.cs
+++ b/accounts-api/src/WebApi/Modules/Common/BusinessMetrics.cs
@@ -58,28 +58,28 @@ public sealed class BusinessMetrics
     /// <summary>Records a deposit transaction.</summary>
     public void RecordDeposit(decimal amount, string currency)
     {
-        _depositsTotal.Add(1, new KeyValuePair<string, object>("currency", currency));
+        _depositsTotal.Add(1, new KeyValuePair<string, object?>("currency", currency));
         _transactionAmounts.Record((double)amount,
-            new KeyValuePair<string, object>("type", "deposit"),
-            new KeyValuePair<string, object>("currency", currency));
+            new KeyValuePair<string, object?>("type", "deposit"),
+            new KeyValuePair<string, object?>("currency", currency));
     }
 
     /// <summary>Records a withdrawal transaction.</summary>
     public void RecordWithdrawal(decimal amount, string currency)
     {
-        _withdrawalsTotal.Add(1, new KeyValuePair<string, object>("currency", currency));
+        _withdrawalsTotal.Add(1, new KeyValuePair<string, object?>("currency", currency));
         _transactionAmounts.Record((double)amount,
-            new KeyValuePair<string, object>("type", "withdrawal"),
-            new KeyValuePair<string, object>("currency", currency));
+            new KeyValuePair<string, object?>("type", "withdrawal"),
+            new KeyValuePair<string, object?>("currency", currency));
     }
 
     /// <summary>Records a transfer transaction.</summary>
     public void RecordTransfer(decimal amount, string currency)
     {
-        _transfersTotal.Add(1, new KeyValuePair<string, object>("currency", currency));
+        _transfersTotal.Add(1, new KeyValuePair<string, object?>("currency", currency));
         _transactionAmounts.Record((double)amount,
-            new KeyValuePair<string, object>("type", "transfer"),
-            new KeyValuePair<string, object>("currency", currency));
+            new KeyValuePair<string, object?>("type", "transfer"),
+            new KeyValuePair<string, object?>("currency", currency));
     }
 
     /// <summary>Records an account opened event.</summary>

--- a/accounts-api/src/WebApi/Modules/Common/ReverseProxyExtensions.cs
+++ b/accounts-api/src/WebApi/Modules/Common/ReverseProxyExtensions.cs
@@ -29,7 +29,7 @@ public static class ReverseProxyExtensions
     /// </summary>
     public static IApplicationBuilder UseProxy(this IApplicationBuilder app, IConfiguration configuration)
     {
-        string basePath = configuration["ASPNETCORE_BASEPATH"];
+        string? basePath = configuration["ASPNETCORE_BASEPATH"];
         if (!string.IsNullOrEmpty(basePath))
         {
             app.Use(async (context, next) =>

--- a/accounts-api/src/WebApi/Modules/HealthChecksExtensions.cs
+++ b/accounts-api/src/WebApi/Modules/HealthChecksExtensions.cs
@@ -71,7 +71,7 @@ public static class HealthChecksExtensions
                 pair => (object)new Dictionary<string, object>
                 {
                     ["status"] = pair.Value.Status.ToString(),
-                    ["description"] = pair.Value.Description,
+                    ["description"] = pair.Value.Description ?? string.Empty,
                     ["data"] = pair.Value.Data.ToDictionary(p => p.Key, p => p.Value)
                 })
         };

--- a/accounts-api/src/WebApi/Program.cs
+++ b/accounts-api/src/WebApi/Program.cs
@@ -48,12 +48,12 @@ public static class Program
         {
             options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
             {
-                diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value);
+                diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value ?? string.Empty);
                 diagnosticContext.Set("UserAgent", httpContext.Request.Headers.UserAgent.ToString());
 
                 if (httpContext.User.Identity?.IsAuthenticated == true)
                 {
-                    diagnosticContext.Set("UserId", httpContext.User.Identity.Name);
+                    diagnosticContext.Set("UserId", httpContext.User.Identity.Name ?? string.Empty);
                 }
             };
         });

--- a/accounts-api/src/WebApi/UseCases/V1/Accounts/CloseAccount/AccountsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V1/Accounts/CloseAccount/AccountsController.cs
@@ -31,7 +31,7 @@ public sealed class AccountsController : ControllerBase, IOutputPort
     private readonly ICloseAccountUseCase _useCase;
     private readonly BusinessMetrics _businessMetrics;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public AccountsController(ICloseAccountUseCase useCase, Notification notification, BusinessMetrics businessMetrics)
     {

--- a/accounts-api/src/WebApi/UseCases/V1/Accounts/GetAccount/AccountsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V1/Accounts/GetAccount/AccountsController.cs
@@ -29,7 +29,7 @@ public sealed class AccountsController : ControllerBase, IOutputPort
 {
     private readonly Notification _notification;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public AccountsController(Notification notification) => this._notification = notification;
 

--- a/accounts-api/src/WebApi/UseCases/V1/Accounts/GetAccounts/AccountsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V1/Accounts/GetAccounts/AccountsController.cs
@@ -27,7 +27,7 @@ public sealed class AccountsController : ControllerBase, IOutputPort
 {
     private readonly IGetAccountsUseCase _useCase;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public AccountsController(IGetAccountsUseCase useCase) => this._useCase = useCase;
 

--- a/accounts-api/src/WebApi/UseCases/V1/Accounts/OpenAccount/AccountsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V1/Accounts/OpenAccount/AccountsController.cs
@@ -30,7 +30,7 @@ public sealed class AccountsController : ControllerBase, IOutputPort
     private readonly Notification _notification;
     private readonly BusinessMetrics _businessMetrics;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public AccountsController(Notification notification, BusinessMetrics businessMetrics)
     {

--- a/accounts-api/src/WebApi/UseCases/V1/Transactions/Deposit/TransactionsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V1/Transactions/Deposit/TransactionsController.cs
@@ -32,7 +32,7 @@ public sealed class TransactionsController : ControllerBase, IOutputPort
     private readonly Notification _notification;
     private readonly BusinessMetrics _businessMetrics;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public TransactionsController(Notification notification, BusinessMetrics businessMetrics)
     {

--- a/accounts-api/src/WebApi/UseCases/V1/Transactions/Transfer/TransactionsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V1/Transactions/Transfer/TransactionsController.cs
@@ -33,7 +33,7 @@ public sealed class TransactionsController : ControllerBase, IOutputPort
     private readonly Notification _notification;
     private readonly BusinessMetrics _businessMetrics;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public TransactionsController(Notification notification, BusinessMetrics businessMetrics)
     {

--- a/accounts-api/src/WebApi/UseCases/V1/Transactions/Withdraw/TransactionsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V1/Transactions/Withdraw/TransactionsController.cs
@@ -33,7 +33,7 @@ public sealed class TransactionsController : ControllerBase, IOutputPort
     private readonly Notification _notification;
     private readonly BusinessMetrics _businessMetrics;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public TransactionsController(Notification notification, BusinessMetrics businessMetrics)
     {

--- a/accounts-api/src/WebApi/UseCases/V2/Accounts/GetAccount/AccountsController.cs
+++ b/accounts-api/src/WebApi/UseCases/V2/Accounts/GetAccount/AccountsController.cs
@@ -30,7 +30,7 @@ public sealed class AccountsController : ControllerBase, IOutputPort
 {
     private readonly Notification _notification;
 
-    private IActionResult _viewModel;
+    private IActionResult? _viewModel;
 
     public AccountsController(Notification notification) => this._notification = notification;
 

--- a/accounts-api/src/WebApi/WebApi.csproj
+++ b/accounts-api/src/WebApi/WebApi.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <NoWarn>$(NoWarn);CA1062;1591;CA1801;S1128;S1481;S1075</NoWarn>
-    <Nullable>disable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/accounts-api/test/ComponentTests/ComponentTests.csproj
+++ b/accounts-api/test/ComponentTests/ComponentTests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Nullable>disable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/accounts-api/test/ComponentTests/CustomWebApplicationFactory.cs
+++ b/accounts-api/test/ComponentTests/CustomWebApplicationFactory.cs
@@ -40,7 +40,7 @@ public sealed class CustomWebApplicationFactory : WebApplicationFactory<Startup>
             (context, config) =>
             {
                 config.AddInMemoryCollection(
-                    new Dictionary<string, string>
+                    new Dictionary<string, string?>
                     {
                         ["FeatureManagement:PostgreSql"] = "true",
                         ["PersistenceModule:DefaultConnection"] = this._postgresContainer.GetConnectionString(),

--- a/accounts-api/test/EndToEndTests/CustomWebApplicationFactory.cs
+++ b/accounts-api/test/EndToEndTests/CustomWebApplicationFactory.cs
@@ -40,7 +40,7 @@ public sealed class CustomWebApplicationFactory : WebApplicationFactory<Startup>
             (context, config) =>
             {
                 config.AddInMemoryCollection(
-                    new Dictionary<string, string>
+                    new Dictionary<string, string?>
                     {
                         ["FeatureManagement:PostgreSql"] = "true",
                         ["PersistenceModule:DefaultConnection"] = this._postgresContainer.GetConnectionString(),

--- a/accounts-api/test/EndToEndTests/EndToEndTests.csproj
+++ b/accounts-api/test/EndToEndTests/EndToEndTests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Nullable>disable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/accounts-api/test/IntegrationTests/IntegrationTests.csproj
+++ b/accounts-api/test/IntegrationTests/IntegrationTests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/accounts-api/test/UnitTests/UnitTests.csproj
+++ b/accounts-api/test/UnitTests/UnitTests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>


### PR DESCRIPTION
## Summary

Enables nullable reference types solution-wide via Directory.Build.props and fixes all resulting warnings for better type safety.

Fixes #26

## Changes
- Added `<Nullable>enable</Nullable>` to Directory.Build.props
- Removed per-project `<Nullable>` and `<NullableReferenceTypes>` settings from all .csproj files (centralized in Directory.Build.props)
- Fixed nullable warnings in Infrastructure project (AccountRepository, AccountRepositoryFake, ContextFactory)
- Fixed nullable warnings in WebApi project (controllers, BusinessMetrics, HealthChecksExtensions, Program, ReverseProxyExtensions)
- Fixed nullable warnings in test projects (ComponentTests, EndToEndTests)
- Added null checks at system boundaries (connection string, environment variable)
- Used `KeyValuePair<string, object?>` for OpenTelemetry metrics compatibility

## Testing
- `dotnet build` completes with no nullable warnings
- No null-forgiving operators added (existing `!` on `_viewModel` returns are pre-existing and correct per the output port pattern)