### PR TITLE
feat: integrate TheAppManager composable module system

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,6 +62,9 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
 
+    <!-- TheAppManager -->
+    <PackageVersion Include="TheAppManager" Version="2.0.0" />
+
     <!-- Serilog -->
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/src/CleanArchitecture.WalletApp/CleanArchitecture.WalletApp.csproj
+++ b/src/CleanArchitecture.WalletApp/CleanArchitecture.WalletApp.csproj
@@ -22,6 +22,10 @@
   </Target>
 
   <ItemGroup>
+    <PackageReference Include="TheAppManager" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../CleanArchitecture.ServiceDefaults/CleanArchitecture.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/src/CleanArchitecture.WalletApp/Modules/AspireDefaultsModule.cs
+++ b/src/CleanArchitecture.WalletApp/Modules/AspireDefaultsModule.cs
@@ -1,0 +1,23 @@
+namespace CleanArchitecture.WalletApp.Modules;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module for Aspire service defaults (OpenTelemetry, health checks, service discovery, resilience).
+/// </summary>
+public sealed class AspireDefaultsModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.AddServiceDefaults();
+    }
+
+    /// <inheritdoc />
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        app.MapDefaultEndpoints();
+    }
+}

--- a/src/CleanArchitecture.WalletApp/Modules/BlazorEndpointsModule.cs
+++ b/src/CleanArchitecture.WalletApp/Modules/BlazorEndpointsModule.cs
@@ -1,0 +1,20 @@
+namespace CleanArchitecture.WalletApp.Modules;
+
+using CleanArchitecture.WalletApp.Components;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module for mapping static assets and Blazor Razor component endpoints.
+/// </summary>
+public sealed class BlazorEndpointsModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapStaticAssets();
+        endpoints.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+    }
+}

--- a/src/CleanArchitecture.WalletApp/Modules/BlazorServicesModule.cs
+++ b/src/CleanArchitecture.WalletApp/Modules/BlazorServicesModule.cs
@@ -1,0 +1,31 @@
+namespace CleanArchitecture.WalletApp.Modules;
+
+using System;
+using CleanArchitecture.WalletApp.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module for Blazor Razor components and HTTP client registration.
+/// </summary>
+public sealed class BlazorServicesModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddRazorComponents()
+            .AddInteractiveServerComponents();
+
+        builder.Services.AddHttpClient<AccountApiClient>(client =>
+        {
+            // When running under Aspire, "https+http://webapi" resolves via service discovery.
+            // Falls back to configuration or localhost for standalone usage.
+            var apiBaseUrl = builder.Configuration["services:webapi:https:0"]
+                            ?? builder.Configuration["services:webapi:http:0"]
+                            ?? builder.Configuration["ApiBaseUrl"]
+                            ?? "http://localhost:5000";
+            client.BaseAddress = new Uri(apiBaseUrl);
+        });
+    }
+}

--- a/src/CleanArchitecture.WalletApp/Modules/MiddlewareModule.cs
+++ b/src/CleanArchitecture.WalletApp/Modules/MiddlewareModule.cs
@@ -1,0 +1,25 @@
+namespace CleanArchitecture.WalletApp.Modules;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module for HTTP middleware pipeline configuration.
+/// </summary>
+public sealed class MiddlewareModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        if (!app.Environment.IsDevelopment())
+        {
+            app.UseExceptionHandler("/Error", createScopeForErrors: true);
+            app.UseHsts();
+        }
+
+        app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
+        app.UseHttpsRedirection();
+        app.UseAntiforgery();
+    }
+}

--- a/src/CleanArchitecture.WalletApp/Program.cs
+++ b/src/CleanArchitecture.WalletApp/Program.cs
@@ -1,41 +1,11 @@
-using CleanArchitecture.WalletApp.Components;
-using CleanArchitecture.WalletApp.Services;
+using CleanArchitecture.WalletApp.Modules;
+using TheAppManager.Startup;
 
-var builder = WebApplication.CreateBuilder(args);
-
-// Add Aspire service defaults (OpenTelemetry, health checks, service discovery, resilience)
-builder.AddServiceDefaults();
-
-builder.Services.AddRazorComponents()
-    .AddInteractiveServerComponents();
-
-builder.Services.AddHttpClient<AccountApiClient>(client =>
+AppManager.Start(args, modules =>
 {
-    // When running under Aspire, "https+http://webapi" resolves via service discovery.
-    // Falls back to configuration or localhost for standalone usage.
-    var apiBaseUrl = builder.Configuration["services:webapi:https:0"]
-                    ?? builder.Configuration["services:webapi:http:0"]
-                    ?? builder.Configuration["ApiBaseUrl"]
-                    ?? "http://localhost:5000";
-    client.BaseAddress = new Uri(apiBaseUrl);
+    modules
+        .Add<AspireDefaultsModule>()
+        .Add<BlazorServicesModule>()
+        .Add<MiddlewareModule>()
+        .Add<BlazorEndpointsModule>();
 });
-
-var app = builder.Build();
-
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler("/Error", createScopeForErrors: true);
-    app.UseHsts();
-}
-
-app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
-app.UseHttpsRedirection();
-app.UseAntiforgery();
-
-app.MapDefaultEndpoints();
-
-app.MapStaticAssets();
-app.MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode();
-
-app.Run();

--- a/src/CleanArchitecture.WebApi/CleanArchitecture.WebApi.csproj
+++ b/src/CleanArchitecture.WebApi/CleanArchitecture.WebApi.csproj
@@ -39,6 +39,7 @@
 
   <ItemGroup>
     <!-- Third party -->
+    <PackageReference Include="TheAppManager" />
 <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Scalar.AspNetCore" />
     <!-- Decorator injection comparison https://greatrexpectations.com/2018/10/25/decorators-in-net-core-with-dependency-injection -->

--- a/src/CleanArchitecture.WebApi/Modules/AppModules/ApplicationServicesModule.cs
+++ b/src/CleanArchitecture.WebApi/Modules/AppModules/ApplicationServicesModule.cs
@@ -1,0 +1,29 @@
+namespace CleanArchitecture.WebApi.Modules.AppModules;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module that delegates to the existing Startup class for application service
+///     registration and HTTP pipeline configuration.
+/// </summary>
+public sealed class ApplicationServicesModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        var startup = new Startup(builder.Configuration);
+        startup.ConfigureServices(builder.Services);
+
+        // Store the Startup instance so ConfigureMiddleware can use it
+        builder.Services.AddSingleton(startup);
+    }
+
+    /// <inheritdoc />
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        var startup = app.Services.GetRequiredService<Startup>();
+        startup.Configure(app, app.Environment);
+    }
+}

--- a/src/CleanArchitecture.WebApi/Modules/AppModules/AspireDefaultsModule.cs
+++ b/src/CleanArchitecture.WebApi/Modules/AppModules/AspireDefaultsModule.cs
@@ -1,0 +1,23 @@
+namespace CleanArchitecture.WebApi.Modules.AppModules;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module for Aspire service defaults (OpenTelemetry, health checks, service discovery, resilience).
+/// </summary>
+public sealed class AspireDefaultsModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.AddServiceDefaults();
+    }
+
+    /// <inheritdoc />
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        app.MapDefaultEndpoints();
+    }
+}

--- a/src/CleanArchitecture.WebApi/Modules/AppModules/ObservabilityModule.cs
+++ b/src/CleanArchitecture.WebApi/Modules/AppModules/ObservabilityModule.cs
@@ -1,0 +1,21 @@
+namespace CleanArchitecture.WebApi.Modules.AppModules;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using CleanArchitecture.WebApi.Modules.Common;
+using OpenTelemetry.Metrics;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module for custom business metrics and OpenTelemetry meter registration.
+/// </summary>
+public sealed class ObservabilityModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<BusinessMetrics>();
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics => metrics.AddMeter(BusinessMetrics.MeterName));
+    }
+}

--- a/src/CleanArchitecture.WebApi/Modules/AppModules/SerilogModule.cs
+++ b/src/CleanArchitecture.WebApi/Modules/AppModules/SerilogModule.cs
@@ -1,0 +1,42 @@
+namespace CleanArchitecture.WebApi.Modules.AppModules;
+
+using Microsoft.AspNetCore.Builder;
+using CleanArchitecture.WebApi.Modules.Common;
+using Serilog;
+using TheAppManager.Modules;
+
+/// <summary>
+///     Module for Serilog structured logging configuration.
+/// </summary>
+public sealed class SerilogModule : IAppModule
+{
+    /// <inheritdoc />
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Host.UseSerilog((context, services, configuration) => configuration
+            .ReadFrom.Configuration(context.Configuration)
+            .ReadFrom.Services(services)
+            .Enrich.FromLogContext()
+            .Enrich.WithMachineName()
+            .Enrich.WithEnvironmentName()
+            .Enrich.With<ActivityEnricher>());
+    }
+
+    /// <inheritdoc />
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        app.UseSerilogRequestLogging(options =>
+        {
+            options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+            {
+                diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value ?? string.Empty);
+                diagnosticContext.Set("UserAgent", httpContext.Request.Headers.UserAgent.ToString());
+
+                if (httpContext.User.Identity?.IsAuthenticated == true)
+                {
+                    diagnosticContext.Set("UserId", httpContext.User.Identity.Name ?? string.Empty);
+                }
+            };
+        });
+    }
+}

--- a/src/CleanArchitecture.WebApi/Program.cs
+++ b/src/CleanArchitecture.WebApi/Program.cs
@@ -1,11 +1,7 @@
 namespace CleanArchitecture.WebApi;
 
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using CleanArchitecture.WebApi.Modules.Common;
-using OpenTelemetry.Metrics;
-using Serilog;
+using CleanArchitecture.WebApi.Modules.AppModules;
+using TheAppManager.Startup;
 
 /// <summary>
 ///     Program entry point.
@@ -18,52 +14,13 @@ public static class Program
     /// <param name="args">Command-line arguments.</param>
     public static void Main(string[] args)
     {
-        var builder = WebApplication.CreateBuilder(args);
-
-        // Configure Serilog from appsettings and enrich with trace context
-        builder.Host.UseSerilog((context, services, configuration) => configuration
-            .ReadFrom.Configuration(context.Configuration)
-            .ReadFrom.Services(services)
-            .Enrich.FromLogContext()
-            .Enrich.WithMachineName()
-            .Enrich.WithEnvironmentName()
-            .Enrich.With<ActivityEnricher>());
-
-        // Add Aspire service defaults (OpenTelemetry, health checks, service discovery, resilience)
-        builder.AddServiceDefaults();
-
-        // Register custom business metrics and add the meter to OpenTelemetry
-        builder.Services.AddSingleton<BusinessMetrics>();
-        builder.Services.AddOpenTelemetry()
-            .WithMetrics(metrics => metrics.AddMeter(BusinessMetrics.MeterName));
-
-        // Configure all application services via the existing Startup class
-        var startup = new Startup(builder.Configuration);
-        startup.ConfigureServices(builder.Services);
-
-        var app = builder.Build();
-
-        // Add Serilog request logging middleware for structured HTTP request logs
-        app.UseSerilogRequestLogging(options =>
+        AppManager.Start(args, modules =>
         {
-            options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
-            {
-                diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value ?? string.Empty);
-                diagnosticContext.Set("UserAgent", httpContext.Request.Headers.UserAgent.ToString());
-
-                if (httpContext.User.Identity?.IsAuthenticated == true)
-                {
-                    diagnosticContext.Set("UserId", httpContext.User.Identity.Name ?? string.Empty);
-                }
-            };
+            modules
+                .Add<SerilogModule>()
+                .Add<AspireDefaultsModule>()
+                .Add<ObservabilityModule>()
+                .Add<ApplicationServicesModule>();
         });
-
-        // Configure the HTTP request pipeline via the existing Startup class
-        startup.Configure(app, app.Environment);
-
-        // Map Aspire default health check endpoints
-        app.MapDefaultEndpoints();
-
-        app.Run();
     }
 }


### PR DESCRIPTION
## Summary

- Integrated the [TheAppManager](https://www.nuget.org/packages/TheAppManager/2.0.0) NuGet package (v2.0.0) into both web projects to replace traditional `Program.cs` setup with a composable module pattern
- Each `Program.cs` now uses `AppManager.Start(args, modules => { ... })` with dedicated `IAppModule` implementations for each logical concern
- **WebApi modules:** `SerilogModule`, `AspireDefaultsModule`, `ObservabilityModule`, `ApplicationServicesModule` (delegates to existing `Startup` class to preserve all service/middleware registrations)
- **WalletApp modules:** `AspireDefaultsModule`, `BlazorServicesModule`, `MiddlewareModule`, `BlazorEndpointsModule`
- No business logic changes -- only startup code reorganization into modules

## Test plan

- [x] Solution builds successfully (`dotnet build` -- 0 errors)
- [x] All unit tests pass (14/14)
- [x] All integration tests pass (3/3)
- [x] All end-to-end tests pass (1/1)
- [x] Pre-existing component test failure confirmed unrelated (exists on main branch)
- [ ] Verify runtime behavior of WebApi endpoints
- [ ] Verify WalletApp Blazor UI renders correctly